### PR TITLE
Extract OtherPage into its own component and show percentages in stats table

### DIFF
--- a/components/app.jsx
+++ b/components/app.jsx
@@ -175,45 +175,6 @@ const App = () => {
 ReactDOM.createRoot(document.getElementById('root')).render(<App/>)
 
 
-const OtherPage = ({ lang, langStats, clientStats, showHiddenMods, setShowHiddenMods }) => {
-	return (
-		<React.Fragment>
-			<div className="container" align="center">
-				<label>
-					<input type="checkbox" checked={showHiddenMods}
-						onChange={e=>setShowHiddenMods(e.target.checked)}
-						style={{marginRight: "0.5em"}}
-					/>
-					<span>{LANG.showHiddenMods[lang]}</span>
-				</label>
-			</div>
-			<div className="container row">
-				<OtherStatsTable caption={LANG.languagesTable[lang]} data={langStats}/>
-				<OtherStatsTable caption={LANG.clientsTable[lang]} data={clientStats}/>
-			</div>
-		</React.Fragment>
-	)
-}
-
-const OtherStatsTable = ({caption, data}) => {
-	return (
-		<table border="1">
-			<caption>{caption}</caption>
-			<tbody>
-				{Object.keys(data).length > 0 ? (
-					<React.Fragment>
-					{Object.entries(data).map(([name, count], index)=>(
-						<tr key={index}>
-							<td>{name}</td>
-							<td style={{textAlign: "right"}}>{count}</td>
-						</tr>
-					))}
-					</React.Fragment>
-				) : <tr><td>Loading...</td></tr>}
-			</tbody>
-		</table>
-	)
-}
 
 async function buildZip(filename, files) {
 	const zip = new JSZip();

--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -1,0 +1,46 @@
+const OtherPage = ({ lang, langStats, clientStats, showHiddenMods, setShowHiddenMods }) => {
+	return (
+		<React.Fragment>
+			<div className="container" align="center">
+				<label>
+					<input type="checkbox" checked={showHiddenMods}
+						onChange={e=>setShowHiddenMods(e.target.checked)}
+						style={{marginRight: "0.5em"}}
+					/>
+					<span>{LANG.showHiddenMods[lang]}</span>
+				</label>
+			</div>
+			<div className="container row">
+				<OtherStatsTable caption={LANG.languagesTable[lang]} data={langStats}/>
+				<OtherStatsTable caption={LANG.clientsTable[lang]} data={clientStats}/>
+			</div>
+		</React.Fragment>
+	)
+}
+
+const OtherStatsTable = ({caption, data}) => {
+	const values = Object.values(data)
+	const total = values.reduce((sum, value) => sum + Number(value), 0)
+
+	return (
+		<table border="1">
+			<caption>{caption}</caption>
+			<tbody>
+				{Object.keys(data).length > 0 ? (
+					<React.Fragment>
+					{Object.entries(data).map(([name, count], index)=>{
+						const percent = total > 0 ? ((Number(count) / total) * 100).toFixed(1) : "0.0"
+						return (
+							<tr key={index}>
+								<td>{name}</td>
+								<td style={{textAlign: "right"}}>{count}</td>
+								<td style={{textAlign: "right"}}>{percent}%</td>
+							</tr>
+						)
+					})}
+					</React.Fragment>
+				) : <tr><td>Loading...</td></tr>}
+			</tbody>
+		</table>
+	)
+}

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
 	<script type='text/babel' data-presets='react' src='components/home.jsx'></script>
 	<script type='text/babel' data-presets='react' src='components/mods_list.jsx'></script>
 	<script type='text/babel' data-presets='react' src='components/mod_preview.jsx'></script>
+	<script type='text/babel' data-presets='react' src='components/other_page.jsx'></script>
 	<script type='text/babel' data-presets='react' src='components/app.jsx'></script>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Separate the `OtherPage` UI out of `components/app.jsx` to improve modularity and reduce the main app file size. 
- Present relative distribution information for language/client stats by adding percentage values to the table.

### Description
- Moved `OtherPage` and `OtherStatsTable` from `components/app.jsx` into a new file `components/other_page.jsx`.
- `OtherStatsTable` now calculates a `total` and shows a percentage column for each row using `toFixed(1)` to display one decimal place.
- Updated `index.html` to include the new script tag for `components/other_page.jsx`.
- Removed the previous inline `OtherPage` and `OtherStatsTable` definitions from `components/app.jsx`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e303cea4832f9dc1b60eada83d7e)