### PR TITLE
Show localized language names in languages table using Intl.DisplayNames

### DIFF
--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -1,4 +1,27 @@
 const OtherPage = ({ lang, langStats, clientStats, showHiddenMods, setShowHiddenMods }) => {
+	const languageDisplayNames = React.useMemo(() => {
+		if (typeof Intl === "undefined" || typeof Intl.DisplayNames !== "function") {
+			return null
+		}
+		return new Intl.DisplayNames([lang], { type: "language" })
+	}, [lang])
+
+	const formatLanguageName = code => {
+		const sourceCode = String(code || "").trim()
+		if (!sourceCode) {
+			return code
+		}
+
+		const normalizedCode = sourceCode.toLowerCase().replace(/_/g, "-")
+		const languageCode = normalizedCode.split("-")[0]
+		const localizedLabel = languageDisplayNames?.of(languageCode)
+		if (!localizedLabel || localizedLabel === languageCode) {
+			return sourceCode
+		}
+
+		return `${sourceCode} (${localizedLabel})`
+	}
+
 	return (
 		<React.Fragment>
 			<div className="container" align="center">
@@ -11,14 +34,18 @@ const OtherPage = ({ lang, langStats, clientStats, showHiddenMods, setShowHidden
 				</label>
 			</div>
 			<div className="container row">
-				<OtherStatsTable caption={LANG.languagesTable[lang]} data={langStats}/>
+				<OtherStatsTable
+					caption={LANG.languagesTable[lang]}
+					data={langStats}
+					nameFormatter={formatLanguageName}
+				/>
 				<OtherStatsTable caption={LANG.clientsTable[lang]} data={clientStats}/>
 			</div>
 		</React.Fragment>
 	)
 }
 
-const OtherStatsTable = ({caption, data}) => {
+const OtherStatsTable = ({caption, data, nameFormatter = name => name}) => {
 	const values = Object.values(data)
 	const total = values.reduce((sum, value) => sum + Number(value), 0)
 
@@ -32,7 +59,7 @@ const OtherStatsTable = ({caption, data}) => {
 						const percent = total > 0 ? ((Number(count) / total) * 100).toFixed(1) : "0.0"
 						return (
 							<tr key={index}>
-								<td>{name}</td>
+								<td>{nameFormatter(name)}</td>
 								<td style={{textAlign: "right"}}>{count}</td>
 								<td style={{textAlign: "right"}}>{percent}%</td>
 							</tr>


### PR DESCRIPTION
### Motivation

- Improve user readability of language codes in the languages statistics table by showing localized language names when available.
- Provide a graceful fallback so original codes are preserved if the environment doesn't support `Intl.DisplayNames` or a localized label cannot be resolved.

### Description

- Add a memoized `languageDisplayNames` using `React.useMemo` that constructs `new Intl.DisplayNames([lang], { type: "language" })` when available.
- Implement `formatLanguageName` to normalize codes (lowercase, convert `_` to `-`, use primary subtag) and return `code (LocalizedName)` when a localized label exists.
- Add a `nameFormatter` prop to `OtherStatsTable` with a default identity formatter and pass `formatLanguageName` for the languages table while leaving the clients table unchanged.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e4e5442c832f801f908713e981f5)