### PR TITLE
Display localized language names in Title Case without language code

### DIFF
--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -15,7 +15,7 @@ const OtherPage = ({ lang, langStats, clientStats, showHiddenMods, setShowHidden
 		if (!localizedLabel || localizedLabel === languageCode) {
 			return sourceCode
 		}
-		return `${sourceCode} (${localizedLabel})`
+		return localizedLabel.charAt(0).toLocaleUpperCase(lang) + localizedLabel.slice(1)
 	}
 
 	return (


### PR DESCRIPTION
### Motivation
- The language list should show only the localized language name in Title Case (first letter uppercase) and omit the raw language code unless localization fails.

### Description
- Updated `components/other_page.jsx` to return the localized language label capitalized via `localizedLabel.charAt(0).toLocaleUpperCase(lang) + localizedLabel.slice(1)` and removed the `sourceCode (localized)` output while keeping the original code as a fallback when localization is unavailable.

### Testing
- Ran `npm run build` which completed successfully.
- Attempted automated UI validation with a Playwright script to capture a screenshot, but the headless Chromium process crashed (SIGSEGV), so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e9065b68832fb36741e6f456c941)