### PR TITLE
Use latest game version when building mod archives

### DIFF
--- a/components/app.jsx
+++ b/components/app.jsx
@@ -3,6 +3,7 @@ const App = () => {
 	const [groups, setGroups] = React.useState([])
 	const [stats, setStats] = React.useState({})
 	const [totalInstalls, setTotalInstalls] = React.useState(0)
+	const [currentGameVersion, setCurrentGameVersion] = React.useState("1.0.0")
 
 	const [showPreview, setShowPreview] = React.useState(false)
 	const [previewData, setPreviewData] = React.useState({})
@@ -27,6 +28,7 @@ const App = () => {
 	React.useEffect(() => {
 		loadStatsPage("2089462923", data=>setStats(statsAsNumber(data)))
 		loadStatsPage("342255871", data=>setTotalInstalls(Math.max(0, data.length-1)))
+		loadStatsPage("379781718", data=>setCurrentGameVersion(getLatestGameVersion(statsAsNumber(data))))
 	}, [])
 
 	React.useEffect(() => {
@@ -73,7 +75,7 @@ const App = () => {
 			version: mod.ver,
 			on_download: _=>{
 				const files = collectFiles(mod.id)
-				buildZip(mod.id, files)
+				buildZip(mod.id, files, currentGameVersion)
 			}
 		})
 		setSelected(mod.id)
@@ -170,4 +172,24 @@ function loadStatsPage(SHEET_ID, callback){
 }
 function statsAsNumber(array){
 	return Object.fromEntries(array.map(([key, value]) => [key, Number(value)]))
+}
+function compareVersions(left, right){
+	const leftParts = String(left).split(".").map(Number)
+	const rightParts = String(right).split(".").map(Number)
+	const maxLength = Math.max(leftParts.length, rightParts.length)
+	for (let i = 0; i < maxLength; i += 1) {
+		const leftPart = leftParts[i] || 0
+		const rightPart = rightParts[i] || 0
+		if (leftPart !== rightPart) {
+			return leftPart - rightPart
+		}
+	}
+	return 0
+}
+function getLatestGameVersion(gameVersionStats){
+	const versions = Object.keys(gameVersionStats || {}).filter(version => /^\d+(\.\d+)+$/.test(version))
+	if (versions.length === 0) {
+		return "1.0.0"
+	}
+	return versions.sort(compareVersions).at(-1)
 }

--- a/components/mod_preview.jsx
+++ b/components/mod_preview.jsx
@@ -97,11 +97,11 @@ function replaceFlags(text) {
 		return part
 	})
 }
-async function buildZip(filename, files) {
+async function buildZip(filename, files, gameVersion = "1.0.0") {
 	const zip = new JSZip();
 	const PATHS = {
-		mods: ["mods", "1.0.0"],
-		res_mods: ["res_mods", "1.0.0"],
+		mods: ["mods", gameVersion],
+		res_mods: ["res_mods", gameVersion],
 		configs: ["mods", "configs"]
 	}
 	for (const file of files) {


### PR DESCRIPTION
### Motivation
- Downloaded mod ZIPs previously contained hardcoded folders `1.0.0` which can be out of sync with the current World of Tanks client version. The goal is to use the latest game version when assembling archive paths.\
- The project already collects game-version distribution stats (`gid=379781718`), so derive the latest version from that sheet and expose it as a single variable.\

### Description
- Added a `currentGameVersion` React state in `App` with default `"1.0.0"` and load it by calling `loadStatsPage("379781718", ...)` to compute the latest version key.\
- Implemented `compareVersions` and `getLatestGameVersion` helpers to parse semantic version keys and pick the newest available version.\
- Updated `on_download` to pass `currentGameVersion` into `buildZip`.\
- Changed `buildZip` signature to `buildZip(filename, files, gameVersion = "1.0.0")` and updated `PATHS` so `mods/<version>` and `res_mods/<version>` use the provided `gameVersion` instead of the hardcoded `1.0.0`.\

### Testing
- Ran `npm run build`, which completed successfully.\
- No automated unit tests were added or run beyond the project build step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b1f878d4832fb11a3d07e5f2f485)