### PR TITLE
Use latest game version in zip builds and pass download handler to preview

### DIFF
--- a/components/app.jsx
+++ b/components/app.jsx
@@ -3,6 +3,7 @@ const App = () => {
 	const [groups, setGroups] = React.useState([])
 	const [stats, setStats] = React.useState({})
 	const [totalInstalls, setTotalInstalls] = React.useState(0)
+	const [currentGameVersion, setCurrentGameVersion] = React.useState("1.0.0")
 
 	const [showPreview, setShowPreview] = React.useState(false)
 	const [previewData, setPreviewData] = React.useState({})
@@ -27,6 +28,7 @@ const App = () => {
 	React.useEffect(() => {
 		loadStatsPage("2089462923", data=>setStats(statsAsNumber(data)))
 		loadStatsPage("342255871", data=>setTotalInstalls(Math.max(0, data.length-1)))
+		loadStatsPage("379781718", data=>setCurrentGameVersion(getLatestGameVersion(statsAsNumber(data))))
 	}, [])
 
 	React.useEffect(() => {
@@ -70,11 +72,7 @@ const App = () => {
 			author: mod.author,
 			image: mod.image,
 			audio: mod.audio,
-			version: mod.ver,
-			on_download: _=>{
-				const files = collectFiles(mod.id)
-				buildZip(mod.id, files)
-			}
+			version: mod.ver
 		})
 		setSelected(mod.id)
 		setShowPreview(true)
@@ -138,6 +136,10 @@ const App = () => {
 					onClosePreview={onClosePreview}
 					previewData={previewData}
 					stats={stats}
+					onDownload={modId=>{
+						const files = collectFiles(modId)
+						buildZip(modId, files, currentGameVersion)
+					}}
 				/>
 			)}
 		</React.Fragment>
@@ -170,4 +172,14 @@ function loadStatsPage(SHEET_ID, callback){
 }
 function statsAsNumber(array){
 	return Object.fromEntries(array.map(([key, value]) => [key, Number(value)]))
+}
+function compareVersions(left, right){
+	return String(left).localeCompare(String(right), undefined, {numeric: true})
+}
+function getLatestGameVersion(gameVersionStats){
+	const versions = Object.keys(gameVersionStats || {}).filter(version => /^\d+(\.\d+)+$/.test(version))
+	if (versions.length === 0) {
+		return "1.0.0"
+	}
+	return versions.sort(compareVersions).at(-1)
 }

--- a/components/mod_preview.jsx
+++ b/components/mod_preview.jsx
@@ -1,4 +1,4 @@
-const ModPreview = ({onClosePreview, previewData, stats}) => {
+const ModPreview = ({onClosePreview, previewData, stats, onDownload}) => {
 	const [visible, setVisible] = React.useState(false);
 	React.useEffect(() => {
 		setVisible(true);
@@ -54,7 +54,7 @@ const ModPreview = ({onClosePreview, previewData, stats}) => {
 					</div>
 				)}
 				<div className="row">
-					<button className="button shine" onClick={previewData.on_download}>
+					<button className="button shine" onClick={_=>onDownload(previewData.id)}>
 						<i className="fa-solid fa-circle-down"></i>
 						<span>{<LANG id="download_button"/>}</span>
 					</button>
@@ -97,11 +97,11 @@ function replaceFlags(text) {
 		return part
 	})
 }
-async function buildZip(filename, files) {
+async function buildZip(filename, files, gameVersion = "1.0.0") {
 	const zip = new JSZip();
 	const PATHS = {
-		mods: ["mods", "1.0.0"],
-		res_mods: ["res_mods", "1.0.0"],
+		mods: ["mods", gameVersion],
+		res_mods: ["res_mods", gameVersion],
 		configs: ["mods", "configs"]
 	}
 	for (const file of files) {


### PR DESCRIPTION
### Motivation

- Ensure downloaded mod archives place files under the correct game-versioned folders by using the latest game version from stats rather than a hardcoded value.
- Decouple the download action from the preview data so the preview component can call a handler that knows the current game version.

### Description

- Added `currentGameVersion` state and load logic that fetches sheet `379781718` and computes the latest numeric version via `getLatestGameVersion` and `compareVersions`.
- Removed the inline `on_download` callback from `previewData` and instead pass an `onDownload` prop into `ModPreview` which calls `collectFiles` and `buildZip(modId, files, currentGameVersion)`.
- Updated `ModPreview` to accept `onDownload` and change the download button to invoke `onDownload(previewData.id)`.
- Modified `buildZip` to accept a `gameVersion` parameter (default `1.0.0`) and use it for the `mods` and `res_mods` PATHS instead of a hardcoded version.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b1f878d4832fb11a3d07e5f2f485)