### PR TITLE
Improve BeforeAfterSlider smoothness on mobile devices

### DIFF
--- a/components/home.jsx
+++ b/components/home.jsx
@@ -140,46 +140,55 @@ const BeforeAfterSlider = ({ before, after }) => {
 	const [dividerPos, setDividerPos] = React.useState(50)
 	const sliderRef = React.useRef(null)
 	const isDragging = React.useRef(false)
+	const frameRef = React.useRef(null)
+	const nextClientXRef = React.useRef(null)
 	
-	const startDrag = () => {
-		isDragging.current = true;
-	}
-	const onDrag = (e) => {
-		if (!isDragging.current) return;
-		const slider = sliderRef.current;
-		if (!slider) return;
+	const updateDividerPos = React.useCallback((clientX) => {
+		const slider = sliderRef.current
+		if (!slider) return
 
 		const rect = slider.getBoundingClientRect()
-		let clientX;
+		let offsetX = clientX - rect.left
+		if (offsetX < 0) offsetX = 0
+		if (offsetX > rect.width) offsetX = rect.width
 
-		if (e.type.startsWith("touch")) {
-			clientX = e.touches[0].clientX;
-		} else {
-			clientX = e.clientX;
-		}
-
-		let offsetX = clientX - rect.left;
-		if (offsetX < 0) offsetX = 0;
-		if (offsetX > rect.width) offsetX = rect.width;
-
-		const percent = (offsetX / rect.width) * 100;
+		const percent = (offsetX / rect.width) * 100
 		setDividerPos(percent)
-	}
-	const stopDrag = () => {
-		isDragging.current = false;
-	}
-	React.useEffect(() => {
-		window.addEventListener("mousemove", onDrag)
-		window.addEventListener("mouseup", stopDrag)
-		window.addEventListener("touchmove", onDrag)
-		window.addEventListener("touchend", stopDrag)
-		return () => {
-			window.removeEventListener("mousemove", onDrag)
-			window.removeEventListener("mouseup", stopDrag)
-			window.removeEventListener("touchmove", onDrag)
-			window.removeEventListener("touchend", stopDrag)
-		}
 	}, [])
+	const flushDragPosition = React.useCallback(() => {
+		frameRef.current = null
+		if (nextClientXRef.current == null) return
+		updateDividerPos(nextClientXRef.current)
+	}, [updateDividerPos])
+	const queueDragPosition = React.useCallback((clientX) => {
+		nextClientXRef.current = clientX
+		if (frameRef.current != null) return
+		frameRef.current = requestAnimationFrame(flushDragPosition)
+	}, [flushDragPosition])
+	const startDrag = React.useCallback((e) => {
+		isDragging.current = true;
+		queueDragPosition(e.clientX)
+	}, [queueDragPosition])
+	const onDrag = React.useCallback((e) => {
+		if (!isDragging.current) return;
+		queueDragPosition(e.clientX)
+	}, [queueDragPosition])
+	const stopDrag = React.useCallback(() => {
+		isDragging.current = false;
+	}, [])
+	React.useEffect(() => {
+		window.addEventListener("pointermove", onDrag)
+		window.addEventListener("pointerup", stopDrag)
+		window.addEventListener("pointercancel", stopDrag)
+		return () => {
+			window.removeEventListener("pointermove", onDrag)
+			window.removeEventListener("pointerup", stopDrag)
+			window.removeEventListener("pointercancel", stopDrag)
+			if (frameRef.current != null) {
+				cancelAnimationFrame(frameRef.current)
+			}
+		}
+	}, [onDrag, stopDrag])
 	return (
 		<div className="ba-slider" ref={sliderRef}>
 			<img src={after} className="ba-image" draggable={false} />
@@ -189,8 +198,7 @@ const BeforeAfterSlider = ({ before, after }) => {
 			<div
 				className="ba-divider"
 				style={{ left: `${dividerPos}%` }}
-				onMouseDown={startDrag}
-				onTouchStart={startDrag}
+				onPointerDown={startDrag}
 			></div>
 		</div>
 	)

--- a/web/main.css
+++ b/web/main.css
@@ -404,6 +404,7 @@ table td, table caption{
 	height: 75dvh;
 	border-radius: 1rem;
 	overflow: hidden;
+	touch-action: none;
 }
 .ba-image{
 	width: 100%;
@@ -432,6 +433,7 @@ table td, table caption{
 	display: flex;
 	justify-content: center;
 	pointer-events: all;
+	touch-action: none;
 }
 .ba-divider::after {
 	content: '';


### PR DESCRIPTION
### Motivation
- The `BeforeAfterSlider` was experiencing lag and gesture contention on touch devices, causing a poor user experience during fast swipes.
- The goal is to reduce re-render pressure during dragging and prevent the browser from interpreting touch gestures as scrolling while interacting with the slider.

### Description
- Replaced separate `mouse`/`touch` handling with unified pointer events and switched the divider `onMouseDown`/`onTouchStart` to `onPointerDown` to simplify event flow and improve consistency (`components/home.jsx`).
- Throttled divider updates by batching clientX values and applying updates inside `requestAnimationFrame` using `frameRef` and `nextClientXRef`, and added `updateDividerPos`, `queueDragPosition`, and `flushDragPosition` helpers to reduce React state churn (`components/home.jsx`).
- Converted handlers to `useCallback` and added proper cleanup including `cancelAnimationFrame` on unmount, and adjusted effect dependencies for stable listeners (`components/home.jsx`).
- Prevented gesture/scroll contention on mobile by adding `touch-action: none` to the slider and divider CSS rules (`web/main.css`).

### Testing
- Ran the build with `npm run build` and it completed successfully (React build finished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55a5af2a4832fa7ff155b17979d40)