### PR TITLE
Fix popup opening jump with dedicated enter/exit animations

### DIFF
--- a/components/mod_preview.jsx
+++ b/components/mod_preview.jsx
@@ -1,6 +1,6 @@
 const ModPreview = ({onClosePreview, previewData, collectFiles}) => {
 	const {lang, langData} = useApp()
-	const [visible, setVisible] = React.useState(false)
+	const [isClosing, setIsClosing] = React.useState(false)
 	const [stats, setStats] = React.useState({})
 	const [currentGameVersion, setCurrentGameVersion] = React.useState("1.0.0")
 
@@ -10,15 +10,13 @@ const ModPreview = ({onClosePreview, previewData, collectFiles}) => {
 	}, [])
 	
 	React.useEffect(() => {
-		setVisible(true);
 		document.body.style.overflow = 'hidden';
 		return ()=> document.body.style.overflow = 'unset';
 	}, []);
 	const BeforeClose = _=>{
-		if (visible){
-			setVisible(false)
-			setTimeout(_=>{ onClosePreview() }, 300)
-		}
+		if (isClosing){return}
+		setIsClosing(true)
+		setTimeout(_=>{ onClosePreview() }, 350)
 	}
 	const onDownload = _=>{
 		const files = collectFiles(previewData.id)
@@ -31,7 +29,7 @@ const ModPreview = ({onClosePreview, previewData, collectFiles}) => {
 	}
 	
 	return (
-		<div className={`popup ${visible ? "visible" : "hidden"}`}
+		<div className={`popup ${isClosing ? "hidden" : "visible"}`}
 			onClick={e=>e.target.classList.contains("popup") && BeforeClose()}
 		>
 			<div className="container popup-content">

--- a/web/main.css
+++ b/web/main.css
@@ -192,17 +192,17 @@ nav{
 }
 
 .popup{
-	background: transparent;
 	position: fixed;
 	inset: 0;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	z-index: 10;
-	transition: 0.35s;
+	background: rgba(0, 0, 0, 0.5);
+	animation: popup-overlay-enter 0.35s ease both;
 }
-.popup.visible{
-	background: rgb(0, 0, 0, 0.5);
+.popup.hidden{
+	animation: popup-overlay-exit 0.35s ease both;
 }
 .popup-content{
 	background: rgba(100,100,100,0.25);
@@ -216,12 +216,11 @@ nav{
 	min-width: 40dvw;
 	gap: 1rem;
 	backdrop-filter: blur(10px);
-}
-.popup.visible .popup-content{
-	animation: reveal-enter 0.35s ease backwards;
+	will-change: transform, opacity;
+	animation: popup-content-enter 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 .popup.hidden .popup-content{
-	animation: reveal-exit 0.35s ease backwards;
+	animation: popup-content-exit 0.35s ease both;
 }
 .image-container{
 	height: 300px;
@@ -528,6 +527,43 @@ table td, table caption{
 	to {
 		opacity: 0;
 		transform: translateY(16px) scale(0.985);
+	}
+}
+
+@keyframes popup-overlay-enter {
+	from {
+		background: rgba(0, 0, 0, 0);
+	}
+	to {
+		background: rgba(0, 0, 0, 0.5);
+	}
+}
+@keyframes popup-overlay-exit {
+	from {
+		background: rgba(0, 0, 0, 0.5);
+	}
+	to {
+		background: rgba(0, 0, 0, 0);
+	}
+}
+@keyframes popup-content-enter {
+	from {
+		opacity: 0;
+		transform: translateY(18px) scale(0.985);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+@keyframes popup-content-exit {
+	from {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+	to {
+		opacity: 0;
+		transform: translateY(18px) scale(0.985);
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Устранить заметный «прыжок» и резкий сдвиг blur при открытии попапа, который происходил из-за рендера компонента в состоянии exit перед запуском открытия. 
- Сделать плавную и предсказуемую анимацию открытия/закрытия, чтобы избежать проблем с применением `backdrop-filter` при использовании `transition`.

### Description
- Заменён флаг рендера `visible` на явный `isClosing` в `components/mod_preview.jsx` и удалён начальный `hidden -> visible` toggle, чтобы попап рендерился сразу в открывающемся состоянии. 
- Логика закрытия переключает `isClosing` и вызывает `onClosePreview` по таймауту, согласованному с длительностью анимации (`350ms`).
- В `web/main.css` удалён смешанный `transition`-подход и добавлены отдельные keyframes для оверлея и контента: `popup-overlay-enter/exit` и `popup-content-enter/exit`, а также `will-change` и кастомная кривая eased-anim для контента. 
- Изменён класс контейнера так, чтобы оверлей всегда отображал затемнение, а видимость контента контролировалась через классы и keyframes для исключения «первого кадра» с exit-анимацией.

### Testing
- Запущена сборка проекта командой `node build.js`, сборка прошла успешно. 
- Генерация артефактов (`dist/app.js`, `dist/web/*`) прошла во время проверки и не включена в изменения.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6880b43c8832fbb5edbbbb5cae458)