### PR TITLE
Add installs-over-time chart based on CSV timestamps

### DIFF
--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -3,6 +3,7 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 	const [clientStats, setClientStats] = React.useState({})
 	const [gameVersionStats, setGameVersionStats] = React.useState({})
 	const [layoutStats, setLayoutStats] = React.useState({})
+	const [timelineStats, setTimelineStats] = React.useState({})
 	const {lang, langData} = useApp()
 
 	React.useEffect(_=>{
@@ -10,6 +11,7 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 		setClientStats(countByField(stats, "WoT type"))
 		setGameVersionStats(countByField(stats, "WoT version", null, (a, b)=>compareVersions(b[0],a[0])))
 		setLayoutStats(countByField(stats, "Layout"))
+		setTimelineStats(countByTimestamp(stats, "Отметка времени"))
 	}, [stats])
 
 	const capitalize = text => text.charAt(0).toUpperCase() + text.slice(1).toLowerCase()
@@ -85,6 +87,12 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 						nameFormatter={val=>layout_type[val] || val}
 					/>
 				</div>
+				<div className="row">
+					<TimelineChart
+						data={timelineStats}
+						caption={langData?.["installsTimeline"]?.[lang]}
+					/>
+				</div>
 			</div>
 		</React.Fragment>
 	)
@@ -148,6 +156,60 @@ const StatsChart = ({
 	return <div style={{height: height + "px"}}><canvas ref={canvasRef}/></div>
 }
 
+const TimelineChart = ({data, caption = null}) => {
+	const canvasRef = React.useRef(null)
+	const validEntries = Object.entries(data).filter(([key, value]) => key && !isNaN(Number(value)))
+	React.useEffect(()=>{
+		if (!canvasRef.current || validEntries.length === 0) { return }
+		const labels = validEntries.map(([label])=>label)
+		const values = validEntries.map(([, value])=>value)
+
+		const chart = new Chart(canvasRef.current,{
+			type:"line",
+			data:{
+				labels,
+				datasets: [{
+					label: caption,
+					data: values,
+					fill: false,
+					tension: 0.2
+				}]
+			},
+			options:{
+				responsive:true,
+				maintainAspectRatio:false,
+				plugins:{
+					title: {
+						display: caption ? true : false,
+						text: caption
+					},
+					legend: {
+						display: false
+					}
+				},
+				scales: {
+					x: {
+						ticks: {
+							maxRotation: 0,
+							autoSkip: true,
+							maxTicksLimit: 10
+						}
+					},
+					y: {
+						beginAtZero: true,
+						title: {
+							display: true,
+							text: "Count"
+						}
+					}
+				}
+			}
+		})
+		return ()=>{chart.destroy()}
+	}, [data, caption])
+	return <div style={{height: "320px", width: "100%"}}><canvas ref={canvasRef}/></div>
+}
+
 function countByField(data, keyField, filterFn = null, sortFn = null) {
 	const counts = data.reduce((acc, row) => {
 		if (filterFn && !filterFn(row)) return acc;
@@ -159,6 +221,39 @@ function countByField(data, keyField, filterFn = null, sortFn = null) {
 	return Object.fromEntries(
 		Object.entries(counts).sort(sortFn || ((a, b) => b[1] - a[1]))
 	)
+}
+
+function countByTimestamp(data, keyField) {
+	const counts = data.reduce((acc, row) => {
+		const parsedDate = parseRuTimestamp(row[keyField])
+		if (!parsedDate) return acc
+		const year = parsedDate.getUTCFullYear()
+		const month = String(parsedDate.getUTCMonth() + 1).padStart(2, "0")
+		const day = String(parsedDate.getUTCDate()).padStart(2, "0")
+		const key = `${year}-${month}-${day}`
+		acc[key] = (acc[key] || 0) + 1
+		return acc
+	}, {})
+	return Object.fromEntries(
+		Object.entries(counts).sort((a, b) => new Date(a[0]) - new Date(b[0]))
+	)
+}
+
+function parseRuTimestamp(value) {
+	const text = String(value || "").trim()
+	const match = text.match(/^(\d{2})\.(\d{2})\.(\d{4})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?$/)
+	if (!match) {
+		return null
+	}
+	const [, day, month, year, hour, minute, second = "0"] = match
+	return new Date(Date.UTC(
+		Number(year),
+		Number(month) - 1,
+		Number(day),
+		Number(hour),
+		Number(minute),
+		Number(second)
+	))
 }
 function countBySplitField(data, keyField, separator = ",", filterFn = null, sortFn = null) {
 	const allValues = data.flatMap(row => {

--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -11,7 +11,7 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 		setClientStats(countByField(stats, "WoT type"))
 		setGameVersionStats(countByField(stats, "WoT version", null, (a, b)=>compareVersions(b[0],a[0])))
 		setLayoutStats(countByField(stats, "Layout"))
-		setTimelineStats(countByTimestamp(stats, "Отметка времени"))
+		setTimelineStats(countByTimestamp(stats, "Timestamp"))
 	}, [stats])
 
 	const capitalize = text => text.charAt(0).toUpperCase() + text.slice(1).toLowerCase()
@@ -87,8 +87,9 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 						nameFormatter={val=>layout_type[val] || val}
 					/>
 				</div>
-				<div className="row">
-					<TimelineChart
+				<div className="row" style={{width: "100%"}}>
+					<StatsChart
+						type="line"
 						data={timelineStats}
 						caption={langData?.["installsTimeline"]?.[lang]}
 					/>
@@ -119,17 +120,18 @@ const StatsChart = ({
 				labels,
 				datasets: [{
 					data: values,
-					borderRadius: type === "bar" ? 6 : 0,
-					borderWidth: type === "bar" ? 1 : 0,
-				}]
+					...(type === "bar" && { borderRadius: 6, borderWidth: 1 }),
+					...(type === "doughnut" && { borderWidth: 0 }),
+					...(type === "line" && { fill: false, tension: 0.2 }),
+				}],
 			},
 			options:{
 				responsive:true,
 				maintainAspectRatio:false,
-				indexAxis:"y",
+				indexAxis: type === "bar" ? "y" : "x",
 				plugins:{
 					legend: {
-						display: type === "bar" ? false : true,
+						display: type === "doughnut" ? true : false,
 						position: 'top',
 						onClick: function(e, legendItem, legend) {}
 					},
@@ -152,62 +154,13 @@ const StatsChart = ({
 		return ()=>{chart.destroy()}
 	},[data, caption])
 	const rowHeight = 25
-	const height = (type === "bar") ? (Object.keys(validEntries).length * rowHeight + 60) : 300
-	return <div style={{height: height + "px"}}><canvas ref={canvasRef}/></div>
-}
-
-const TimelineChart = ({data, caption = null}) => {
-	const canvasRef = React.useRef(null)
-	const validEntries = Object.entries(data).filter(([key, value]) => key && !isNaN(Number(value)))
-	React.useEffect(()=>{
-		if (!canvasRef.current || validEntries.length === 0) { return }
-		const labels = validEntries.map(([label])=>label)
-		const values = validEntries.map(([, value])=>value)
-
-		const chart = new Chart(canvasRef.current,{
-			type:"line",
-			data:{
-				labels,
-				datasets: [{
-					label: caption,
-					data: values,
-					fill: false,
-					tension: 0.2
-				}]
-			},
-			options:{
-				responsive:true,
-				maintainAspectRatio:false,
-				plugins:{
-					title: {
-						display: caption ? true : false,
-						text: caption
-					},
-					legend: {
-						display: false
-					}
-				},
-				scales: {
-					x: {
-						ticks: {
-							maxRotation: 0,
-							autoSkip: true,
-							maxTicksLimit: 10
-						}
-					},
-					y: {
-						beginAtZero: true,
-						title: {
-							display: true,
-							text: "Count"
-						}
-					}
-				}
-			}
-		})
-		return ()=>{chart.destroy()}
-	}, [data, caption])
-	return <div style={{height: "320px", width: "100%"}}><canvas ref={canvasRef}/></div>
+	const height = type === "bar" ? (Object.keys(validEntries).length * rowHeight + 60) : 300
+	return <div style={{
+		height: height + "px",
+		width: type === "line" ? "100%" : undefined
+	}}>
+		<canvas ref={canvasRef}/>
+	</div>
 }
 
 function countByField(data, keyField, filterFn = null, sortFn = null) {
@@ -221,39 +174,6 @@ function countByField(data, keyField, filterFn = null, sortFn = null) {
 	return Object.fromEntries(
 		Object.entries(counts).sort(sortFn || ((a, b) => b[1] - a[1]))
 	)
-}
-
-function countByTimestamp(data, keyField) {
-	const counts = data.reduce((acc, row) => {
-		const parsedDate = parseRuTimestamp(row[keyField])
-		if (!parsedDate) return acc
-		const year = parsedDate.getUTCFullYear()
-		const month = String(parsedDate.getUTCMonth() + 1).padStart(2, "0")
-		const day = String(parsedDate.getUTCDate()).padStart(2, "0")
-		const key = `${year}-${month}-${day}`
-		acc[key] = (acc[key] || 0) + 1
-		return acc
-	}, {})
-	return Object.fromEntries(
-		Object.entries(counts).sort((a, b) => new Date(a[0]) - new Date(b[0]))
-	)
-}
-
-function parseRuTimestamp(value) {
-	const text = String(value || "").trim()
-	const match = text.match(/^(\d{2})\.(\d{2})\.(\d{4})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?$/)
-	if (!match) {
-		return null
-	}
-	const [, day, month, year, hour, minute, second = "0"] = match
-	return new Date(Date.UTC(
-		Number(year),
-		Number(month) - 1,
-		Number(day),
-		Number(hour),
-		Number(minute),
-		Number(second)
-	))
 }
 function countBySplitField(data, keyField, separator = ",", filterFn = null, sortFn = null) {
 	const allValues = data.flatMap(row => {
@@ -269,4 +189,33 @@ function countBySplitField(data, keyField, separator = ",", filterFn = null, sor
 	return Object.fromEntries(
 		Object.entries(counts).sort(sortFn || ((a, b) => b[1] - a[1]))
 	)
+}
+
+function countByTimestamp(data, keyField) {
+	return data.reduce((acc, row) => {
+		const parsedDate = parseRuTimestamp(row[keyField])
+		if (!parsedDate) return acc
+		const year = String(parsedDate.getUTCFullYear()).slice(-2)
+		const month = String(parsedDate.getUTCMonth() + 1).padStart(2, "0")
+		const day = String(parsedDate.getUTCDate()).padStart(2, "0")
+		const key = `${day}-${month}-${year}`
+		acc[key] = (acc[key] || 0) + 1
+		return acc
+	}, {})
+}
+function parseRuTimestamp(value) {
+	const text = String(value || "").trim()
+	const match = text.match(/^(\d{2})\.(\d{2})\.(\d{4})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?$/)
+	if (!match) {
+		return null
+	}
+	const [, day, month, year, hour, minute, second = "0"] = match
+	return new Date(Date.UTC(
+		Number(year),
+		Number(month) - 1,
+		Number(day),
+		Number(hour),
+		Number(minute),
+		Number(second)
+	))
 }

--- a/web/lang.json
+++ b/web/lang.json
@@ -165,9 +165,9 @@
 		"uk": "Список"
 	},
 	"installsTimeline": {
-		"en": "Installs over time",
-		"ru": "Установки по времени",
-		"uk": "Встановлення за часом"
+		"en": "Installations",
+		"ru": "Установки",
+		"uk": "Встановлення"
 	},
 	"loading": {
 		"en": "Loading...",

--- a/web/lang.json
+++ b/web/lang.json
@@ -164,6 +164,11 @@
 		"ru": "Список",
 		"uk": "Список"
 	},
+	"installsTimeline": {
+		"en": "Installs over time",
+		"ru": "Установки по времени",
+		"uk": "Встановлення за часом"
+	},
 	"loading": {
 		"en": "Loading...",
 		"ru": "Загрузка...",


### PR DESCRIPTION
### Motivation
- Provide a time-based visualization of installs using the CSV `Отметка времени` column to better understand install trends over time.

### Description
- Added `timelineStats` aggregation in `OtherPage` using a new `countByTimestamp` helper that groups parsed timestamps by day (`YYYY-MM-DD`).
- Implemented `parseRuTimestamp` to parse Russian-format timestamps like `DD.MM.YYYY H:mm:ss` into UTC `Date` objects and used it in `countByTimestamp`.
- Added a new `TimelineChart` component (line chart) that draws installs-over-time with Chart.js and a new i18n key `installsTimeline` in `web/lang.json` for EN/RU/UK.
- Changes applied in `components/other_page.jsx` and `web/lang.json` to wire aggregation, chart rendering, and translations.

### Testing
- Ran `npm run build` and the build completed successfully (React build and asset copy steps reported OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1a6d1eb4832fa1b8e77a9e1d5bea)