### PR TITLE
Add install logging and on-demand log viewer

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -138,7 +138,7 @@ def _main_install_worker(client_path, args, mods):
 	if client.is_running:
 		add_install_log("Installation stopped: client is currently running.", level="error")
 		fails.append({"error": "client_is_running_error"})
-		return fails
+		return eel.on_install_finish(fails)()
 	if args.get("delete_mods", False):
 		add_install_log(
 			f"Deleting existing mods (delete_configs={args.get('delete_configs', False)}).",
@@ -150,7 +150,7 @@ def _main_install_worker(client_path, args, mods):
 		except Exception as e:
 			add_install_log(f"Failed while deleting mods: {e}", level="error")
 			fails.append({"error": str(e)})
-			return fails
+			return eel.on_install_finish(fails)()
 	
 	if len(mods) > 0:
 		mods_arr = list(filter(bool, map(json_to_mod, mods)))
@@ -173,8 +173,7 @@ def _main_install_worker(client_path, args, mods):
 					add_install_log(f"Mod installation completed: {mod.id}", level="info")
 			except Exception as e:
 				add_install_log(f"Exception during mod installation ({mod.id}): {e}", level="error")
-				fails.append({"error": str(e)})
-				return fails
+				fails.append({"mod": mod.id})
 
 		add_install_log("Sending telemetry for completed installation.", level="debug")
 		telemetry.send_telemetry(

--- a/src/main.py
+++ b/src/main.py
@@ -91,8 +91,11 @@ def set_mods_data(data):
 def get_install_logs():
 	return INSTALL_LOGS
 
-def add_install_log(message):
-	INSTALL_LOGS.append(message)
+def add_install_log(message, level="info"):
+	INSTALL_LOGS.append({
+		"level": level,
+		"message": message
+	})
 
 
 def download_progress(current, total):
@@ -125,7 +128,7 @@ def _main_install_worker(client_path, args, mods):
 	global INSTALL_LOGS
 	INSTALL_LOGS = []
 	fails = []
-	add_install_log(f"Install worker started for client: {client_path}")
+	add_install_log(f"Install worker started for client: {client_path}", level="info")
 	client = Client(
 		client_path,
 		use_cache=SETTINGS.get("use_cache", True),
@@ -133,27 +136,28 @@ def _main_install_worker(client_path, args, mods):
 	)
 
 	if client.is_running:
-		add_install_log("Installation stopped: client is currently running.")
+		add_install_log("Installation stopped: client is currently running.", level="error")
 		fails.append({"error": "client_is_running_error"})
 		return fails
 	if args.get("delete_mods", False):
 		add_install_log(
-			f"Deleting existing mods (delete_configs={args.get('delete_configs', False)})."
+			f"Deleting existing mods (delete_configs={args.get('delete_configs', False)}).",
+			level="info"
 		)
 		try:
 			client.delete_mods(args.get("delete_configs", False))
-			add_install_log("Existing mods deletion completed.")
+			add_install_log("Existing mods deletion completed.", level="info")
 		except Exception as e:
-			add_install_log(f"Failed while deleting mods: {e}")
+			add_install_log(f"Failed while deleting mods: {e}", level="error")
 			fails.append({"error": str(e)})
 			return fails
 	
 	if len(mods) > 0:
 		mods_arr = list(filter(bool, map(json_to_mod, mods)))
 		total_mods = len(mods_arr)
-		add_install_log(f"Preparing to install {total_mods} mod(s).")
+		add_install_log(f"Preparing to install {total_mods} mod(s).", level="info")
 		for index, mod in enumerate(mods_arr):
-			add_install_log(f"Installing mod {index + 1}/{total_mods}: {mod.id}")
+			add_install_log(f"Installing mod {index + 1}/{total_mods}: {mod.id}", level="info")
 			eel.installing_progress({
 				"id": mod.id,
 				"current": index,
@@ -163,16 +167,16 @@ def _main_install_worker(client_path, args, mods):
 			try:
 				result = client.install_mod(mod, on_progress=download_progress)
 				if not result:
-					add_install_log(f"Mod installation returned failure: {mod.id}")
+					add_install_log(f"Mod installation returned failure: {mod.id}", level="error")
 					fails.append({"mod": mod.id})
 				else:
-					add_install_log(f"Mod installation completed: {mod.id}")
+					add_install_log(f"Mod installation completed: {mod.id}", level="info")
 			except Exception as e:
-				add_install_log(f"Exception during mod installation ({mod.id}): {e}")
+				add_install_log(f"Exception during mod installation ({mod.id}): {e}", level="error")
 				fails.append({"error": str(e)})
 				return fails
 
-		add_install_log("Sending telemetry for completed installation.")
+		add_install_log("Sending telemetry for completed installation.", level="debug")
 		telemetry.send_telemetry(
 			mod_ids=mods,
 			modpack_ver=__version__,
@@ -185,13 +189,13 @@ def _main_install_worker(client_path, args, mods):
 		)
 
 	if args.get("save_selected_mods", True):
-		add_install_log("Saving selected mods and client path to settings.")
+		add_install_log("Saving selected mods and client path to settings.", level="debug")
 		update_settings({
 			"client": client_path,
 			"mods": mods
 		})
 
-	add_install_log(f"Install worker finished with {len(fails)} failure(s).")
+	add_install_log(f"Install worker finished with {len(fails)} failure(s).", level="info")
 	eel.on_install_finish(fails)()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from tkinter.filedialog import askdirectory
 from utils import *
 
 MODS_DATA = {}
+INSTALL_LOGS = []
 __version__ = "2.4.0"
 @eel.expose
 def app_version(): return __version__
@@ -86,6 +87,13 @@ def set_mods_data(data):
 	global MODS_DATA
 	MODS_DATA = data
 
+@eel.expose
+def get_install_logs():
+	return INSTALL_LOGS
+
+def add_install_log(message):
+	INSTALL_LOGS.append(message)
+
 
 def download_progress(current, total):
 	eel.installing_progress({"download_progress":round(current / total * 100)})
@@ -114,23 +122,38 @@ def main_install(path, args, mods):
 	).start()
 
 def _main_install_worker(client_path, args, mods):
+	global INSTALL_LOGS
+	INSTALL_LOGS = []
 	fails = []
-	client = Client(client_path, use_cache=SETTINGS.get("use_cache", True))
+	add_install_log(f"Install worker started for client: {client_path}")
+	client = Client(
+		client_path,
+		use_cache=SETTINGS.get("use_cache", True),
+		logger=add_install_log
+	)
 
 	if client.is_running:
+		add_install_log("Installation stopped: client is currently running.")
 		fails.append({"error": "client_is_running_error"})
 		return fails
 	if args.get("delete_mods", False):
+		add_install_log(
+			f"Deleting existing mods (delete_configs={args.get('delete_configs', False)})."
+		)
 		try:
 			client.delete_mods(args.get("delete_configs", False))
+			add_install_log("Existing mods deletion completed.")
 		except Exception as e:
+			add_install_log(f"Failed while deleting mods: {e}")
 			fails.append({"error": str(e)})
 			return fails
 	
 	if len(mods) > 0:
 		mods_arr = list(filter(bool, map(json_to_mod, mods)))
 		total_mods = len(mods_arr)
+		add_install_log(f"Preparing to install {total_mods} mod(s).")
 		for index, mod in enumerate(mods_arr):
+			add_install_log(f"Installing mod {index + 1}/{total_mods}: {mod.id}")
 			eel.installing_progress({
 				"id": mod.id,
 				"current": index,
@@ -139,11 +162,17 @@ def _main_install_worker(client_path, args, mods):
 			})
 			try:
 				result = client.install_mod(mod, on_progress=download_progress)
-				if not result: fails.append({"mod": mod.id})
+				if not result:
+					add_install_log(f"Mod installation returned failure: {mod.id}")
+					fails.append({"mod": mod.id})
+				else:
+					add_install_log(f"Mod installation completed: {mod.id}")
 			except Exception as e:
+				add_install_log(f"Exception during mod installation ({mod.id}): {e}")
 				fails.append({"error": str(e)})
 				return fails
 
+		add_install_log("Sending telemetry for completed installation.")
 		telemetry.send_telemetry(
 			mod_ids=mods,
 			modpack_ver=__version__,
@@ -156,11 +185,13 @@ def _main_install_worker(client_path, args, mods):
 		)
 
 	if args.get("save_selected_mods", True):
+		add_install_log("Saving selected mods and client path to settings.")
 		update_settings({
 			"client": client_path,
 			"mods": mods
 		})
 
+	add_install_log(f"Install worker finished with {len(fails)} failure(s).")
 	eel.on_install_finish(fails)()
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -91,9 +91,9 @@ class Client:
 		self.appdata = appdata if os.path.exists(appdata) else None
 		self.installed = []
 
-	def _log(self, message):
+	def _log(self, message, level="debug"):
 		if callable(self.logger):
-			self.logger(message)
+			self.logger(message, level=level)
 
 	@property
 	def is_running(self):
@@ -225,9 +225,12 @@ class Client:
 				logger=self.logger
 			)
 			if result: self.installed.append(mod.id)
-			self._log(f"Client.install_mod finished: {mod.id} ({'ok' if result else 'failed'})")
+			self._log(
+				f"Client.install_mod finished: {mod.id} ({'ok' if result else 'failed'})",
+				level="debug" if result else "warn"
+			)
 			return result
-		self._log(f"Client.install_mod skipped (already installed): {mod.id}")
+		self._log(f"Client.install_mod skipped (already installed): {mod.id}", level="debug")
 		return True
 
 
@@ -241,26 +244,26 @@ class Mod:
 	def __repr__(self): return str(self)
 
 	def install(self, client, on_progress=None, use_cache=True, logger=None):
-		def log(message):
+		def log(message, level="debug"):
 			if callable(logger):
-				logger(message)
+				logger(message, level=level)
 
-		log(f"Mod.install started: {self.id}")
+		log(f"Mod.install started: {self.id}", level="info")
 		if self.requires and len(self.requires) > 0:
 			for mod in self.requires:
-				log(f"Installing required mod for {self.id}: {mod.id}")
+				log(f"Installing required mod for {self.id}: {mod.id}", level="debug")
 				client.install_mod(mod)
 
 		write_cache = True
 		if use_cache:
-			log(f"Cache enabled for mod: {self.id}")
+			log(f"Cache enabled for mod: {self.id}", level="debug")
 			self.init_cache()
 			have_cache = self.load_cache_files()
 			if have_cache:
-				log(f"Using cache for mod: {self.id}")
+				log(f"Using cache for mod: {self.id}", level="info")
 				write_cache = False
 			else:
-				log(f"Cache miss for mod: {self.id}")
+				log(f"Cache miss for mod: {self.id}", level="debug")
 				self.delete_from_cache()
 
 		cache_files = []
@@ -277,10 +280,10 @@ class Mod:
 			os.makedirs(target_map[file["dest"]], exist_ok=True)
 
 			if file["url"].startswith("http"):
-				log(f"Downloading file for {self.id}: {file['url']}")
+				log(f"Downloading file for {self.id}: {file['url']}", level="info")
 				file_io = self.download(file["url"], on_progress=on_progress)
 				if not file_io:
-					log(f"Download failed for {self.id}: {file['url']}")
+					log(f"Download failed for {self.id}: {file['url']}", level="error")
 					return False
 
 				if file["url"].endswith(".zip"):
@@ -301,9 +304,9 @@ class Mod:
 						"url": target_file
 					})
 			else:
-				log(f"Using local file for {self.id}: {file['url']}")
+				log(f"Using local file for {self.id}: {file['url']}", level="debug")
 				if not os.path.exists(file["url"]):
-					log(f"Local file not found for {self.id}: {file['url']}")
+					log(f"Local file not found for {self.id}: {file['url']}", level="error")
 					return False
 				if file["url"].endswith(".zip"):
 					with zipfile.ZipFile(file["url"], 'r') as zip_ref:
@@ -317,9 +320,9 @@ class Mod:
 				"ver": self.version,
 				"files": cache_files
 			}])
-			log(f"Cache updated for mod: {self.id}")
+			log(f"Cache updated for mod: {self.id}", level="debug")
 
-		log(f"Mod.install finished: {self.id}")
+		log(f"Mod.install finished: {self.id}", level="info")
 		return True
 
 	def download(self, url, on_progress=None):

--- a/src/utils.py
+++ b/src/utils.py
@@ -82,13 +82,18 @@ class ClientType(Enum):
 	STEAM = "steam"
 
 class Client:
-	def __init__(self, path, use_cache=True):
+	def __init__(self, path, use_cache=True, logger=None):
 		self.path = path
 		self.use_cache = use_cache
+		self.logger = logger
 		self.exe = "WorldOfTanks.exe"
 		appdata = os.path.join(os.getenv('APPDATA'), 'Wargaming.net', 'WorldOfTanks')
 		self.appdata = appdata if os.path.exists(appdata) else None
 		self.installed = []
+
+	def _log(self, message):
+		if callable(self.logger):
+			self.logger(message)
 
 	@property
 	def is_running(self):
@@ -188,6 +193,7 @@ class Client:
 		return el.text.strip() if el is not None else None
 
 	def delete_mods(self, delete_configs=False, delete_logs=True):
+		self._log("Client.delete_mods started.")
 		self.installed = []
 		mods_f = os.path.join(self.path, "mods")
 		res_mods = os.path.join(self.path, "res_mods")
@@ -207,12 +213,21 @@ class Client:
 		if delete_logs:
 			logfile = os.path.join(self.path, "python.log")
 			if os.path.exists(logfile): os.remove(logfile)
+		self._log("Client.delete_mods finished.")
 
 	def install_mod(self, mod, on_progress=None):
 		if not mod.id in self.installed:
-			result = mod.install(self, on_progress=on_progress, use_cache=self.use_cache)
+			self._log(f"Client.install_mod started: {mod.id}")
+			result = mod.install(
+				self,
+				on_progress=on_progress,
+				use_cache=self.use_cache,
+				logger=self.logger
+			)
 			if result: self.installed.append(mod.id)
+			self._log(f"Client.install_mod finished: {mod.id} ({'ok' if result else 'failed'})")
 			return result
+		self._log(f"Client.install_mod skipped (already installed): {mod.id}")
 		return True
 
 
@@ -225,18 +240,27 @@ class Mod:
 	def __str__(self): return f'<Mod "{self.id}">'
 	def __repr__(self): return str(self)
 
-	def install(self, client, on_progress=None, use_cache=True):
+	def install(self, client, on_progress=None, use_cache=True, logger=None):
+		def log(message):
+			if callable(logger):
+				logger(message)
+
+		log(f"Mod.install started: {self.id}")
 		if self.requires and len(self.requires) > 0:
 			for mod in self.requires:
+				log(f"Installing required mod for {self.id}: {mod.id}")
 				client.install_mod(mod)
 
 		write_cache = True
 		if use_cache:
+			log(f"Cache enabled for mod: {self.id}")
 			self.init_cache()
 			have_cache = self.load_cache_files()
 			if have_cache:
+				log(f"Using cache for mod: {self.id}")
 				write_cache = False
 			else:
+				log(f"Cache miss for mod: {self.id}")
 				self.delete_from_cache()
 
 		cache_files = []
@@ -253,8 +277,11 @@ class Mod:
 			os.makedirs(target_map[file["dest"]], exist_ok=True)
 
 			if file["url"].startswith("http"):
+				log(f"Downloading file for {self.id}: {file['url']}")
 				file_io = self.download(file["url"], on_progress=on_progress)
-				if not file_io: return False
+				if not file_io:
+					log(f"Download failed for {self.id}: {file['url']}")
+					return False
 
 				if file["url"].endswith(".zip"):
 					with zipfile.ZipFile(file_io, 'r') as zip_ref:
@@ -274,7 +301,10 @@ class Mod:
 						"url": target_file
 					})
 			else:
-				if not os.path.exists(file["url"]): return False
+				log(f"Using local file for {self.id}: {file['url']}")
+				if not os.path.exists(file["url"]):
+					log(f"Local file not found for {self.id}: {file['url']}")
+					return False
 				if file["url"].endswith(".zip"):
 					with zipfile.ZipFile(file["url"], 'r') as zip_ref:
 						zip_ref.extractall(target_map[file["dest"]])
@@ -287,7 +317,9 @@ class Mod:
 				"ver": self.version,
 				"files": cache_files
 			}])
+			log(f"Cache updated for mod: {self.id}")
 
+		log(f"Mod.install finished: {self.id}")
 		return True
 
 	def download(self, url, on_progress=None):

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -20,6 +20,7 @@
 	<script type="text/babel" data-presets="react" src="src/components/HomeTab.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/CheckoutTab.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/InstallTab.jsx"></script>
+	<script type="text/babel" data-presets="react" src="src/components/InstallLogsViewer.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/FinishTab.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/Settings.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/Gallery.jsx"></script>

--- a/src/web/locales/en.json
+++ b/src/web/locales/en.json
@@ -52,7 +52,7 @@
 	"show_install_logs": "Show install logs",
 	"hide_install_logs": "Hide install logs",
 	"log_level": "Log level",
-	"copy_logs": "Copy logs",
+	"copy_logs": "Копировать",
 	"copied": "Copied",
 	"no_logs_for_selected_level": "No logs for selected level."
 }

--- a/src/web/locales/en.json
+++ b/src/web/locales/en.json
@@ -48,5 +48,11 @@
 	"layout_tooltip": "Try Grid layout!",
 	"data_collection_title": "Data Collection Notice",
 	"data_collection_description": "This modpack automatically collects:",
-	"accept": "Accept"
+	"accept": "Accept",
+	"show_install_logs": "Show install logs",
+	"hide_install_logs": "Hide install logs",
+	"log_level": "Log level",
+	"copy_logs": "Copy logs",
+	"copied": "Copied",
+	"no_logs_for_selected_level": "No logs for selected level."
 }

--- a/src/web/locales/ru.json
+++ b/src/web/locales/ru.json
@@ -51,7 +51,7 @@
 	"accept": "Принять",
 	"show_install_logs": "Показать логи установки",
 	"hide_install_logs": "Скрыть логи установки",
-	"log_level": "Уровень логов",
+	"log_level": "Уровень",
 	"copy_logs": "Копировать",
 	"copied": "Скопировано",
 	"no_logs_for_selected_level": "Нет логов для выбранного уровня."

--- a/src/web/locales/ru.json
+++ b/src/web/locales/ru.json
@@ -48,5 +48,11 @@
 	"layout_tooltip": "Попробуйте вид Сеткой!",
 	"data_collection_title": "Уведомление о сборе данных",
 	"data_collection_description": "Этот модпак автоматически собирает:",
-	"accept": "Принять"
+	"accept": "Принять",
+	"show_install_logs": "Показать логи установки",
+	"hide_install_logs": "Скрыть логи установки",
+	"log_level": "Уровень логов",
+	"copy_logs": "Копировать логи",
+	"copied": "Скопировано",
+	"no_logs_for_selected_level": "Нет логов для выбранного уровня."
 }

--- a/src/web/locales/ru.json
+++ b/src/web/locales/ru.json
@@ -52,7 +52,7 @@
 	"show_install_logs": "Показать логи установки",
 	"hide_install_logs": "Скрыть логи установки",
 	"log_level": "Уровень логов",
-	"copy_logs": "Копировать логи",
+	"copy_logs": "Копировать",
 	"copied": "Скопировано",
 	"no_logs_for_selected_level": "Нет логов для выбранного уровня."
 }

--- a/src/web/locales/uk.json
+++ b/src/web/locales/uk.json
@@ -51,7 +51,7 @@
 	"accept": "Прийняти",
 	"show_install_logs": "Показати логи встановлення",
 	"hide_install_logs": "Сховати логи встановлення",
-	"log_level": "Рівень логів",
+	"log_level": "Рівень",
 	"copy_logs": "Копировать",
 	"copied": "Скопійовано",
 	"no_logs_for_selected_level": "Немає логів для вибраного рівня."

--- a/src/web/locales/uk.json
+++ b/src/web/locales/uk.json
@@ -48,5 +48,11 @@
 	"layout_tooltip": "Спробуйте вид Сіткою!",
 	"data_collection_title": "Повідомлення про збір даних",
 	"data_collection_description": "Цей модпак автоматично збирає:",
-	"accept": "Прийняти"
+	"accept": "Прийняти",
+	"show_install_logs": "Показати логи встановлення",
+	"hide_install_logs": "Сховати логи встановлення",
+	"log_level": "Рівень логів",
+	"copy_logs": "Копіювати логи",
+	"copied": "Скопійовано",
+	"no_logs_for_selected_level": "Немає логів для вибраного рівня."
 }

--- a/src/web/locales/uk.json
+++ b/src/web/locales/uk.json
@@ -52,7 +52,7 @@
 	"show_install_logs": "Показати логи встановлення",
 	"hide_install_logs": "Сховати логи встановлення",
 	"log_level": "Рівень логів",
-	"copy_logs": "Копіювати логи",
+	"copy_logs": "Копировать",
 	"copied": "Скопійовано",
 	"no_logs_for_selected_level": "Немає логів для вибраного рівня."
 }

--- a/src/web/src/components/FinishTab.jsx
+++ b/src/web/src/components/FinishTab.jsx
@@ -2,6 +2,7 @@ const FinishTab = ({
 	fails, mods, selectedMods
 }) => {
 	const { language, langData } = useApp()
+	const [isLogsOpen, setIsLogsOpen] = React.useState(false)
 
 	function getKnownError(){
 		if (fails.filter(x=>x.error).length > 0){
@@ -38,14 +39,14 @@ const FinishTab = ({
 						</React.Fragment>
 					) : null}
 					<br/>
-					<Button href="https://github.com/SuperZombi/wot-modpack/issues" style={{fontSize: "12px"}}>
-						<LANG id="report_bug"/>
-					</Button>
-					<div style={{marginTop: "8px"}}>
-						<InstallLogsViewer/>
-					</div>
-				</React.Fragment>
-			) : (
+						<Button href="https://github.com/SuperZombi/wot-modpack/issues" style={{fontSize: "12px"}}>
+							<LANG id="report_bug"/>
+						</Button>
+						<div style={{marginTop: "8px"}}>
+							<InstallLogsViewer onVisibilityChange={setIsLogsOpen}/>
+						</div>
+					</React.Fragment>
+				) : (
 				<React.Fragment>
 					<br/>
 					<h3>
@@ -67,12 +68,12 @@ const FinishTab = ({
 							<img src="/images/donatello_logo.png" draggable={false}/>
 						</a>
 					</div>
-					<div style={{marginTop: "16px"}}>
-						<InstallLogsViewer/>
-					</div>
-					<Gallery/>
-				</React.Fragment>
-			)}
+						<div style={{marginTop: "16px"}}>
+							<InstallLogsViewer onVisibilityChange={setIsLogsOpen}/>
+						</div>
+						{!isLogsOpen && <Gallery/>}
+					</React.Fragment>
+				)}
 		</div>
 	)
 }

--- a/src/web/src/components/FinishTab.jsx
+++ b/src/web/src/components/FinishTab.jsx
@@ -4,6 +4,12 @@ const FinishTab = ({
 	const { language, langData } = useApp()
 	const [showLogs, setShowLogs] = React.useState(false)
 	const [logs, setLogs] = React.useState([])
+	const [levels, setLevels] = React.useState({
+		info: true,
+		warn: true,
+		error: true,
+		debug: false
+	})
 
 	const toggleLogs = async _ => {
 		if (!showLogs && logs.length === 0){
@@ -12,6 +18,15 @@ const FinishTab = ({
 		}
 		setShowLogs(prev => !prev)
 	}
+	const toggleLevel = level => {
+		setLevels(prev => ({
+			...prev,
+			[level]: !prev[level]
+		}))
+	}
+
+	const visibleLogs = logs.filter(log => levels[log.level] ?? true)
+	const levelItems = ["info", "warn", "error", "debug"]
 
 	function getKnownError(){
 		if (fails.filter(x=>x.error).length > 0){
@@ -55,7 +70,23 @@ const FinishTab = ({
 						{showLogs ? "Hide install logs" : "Show install logs"}
 					</Button>
 					{showLogs && (
-						<pre className="install-logs">{logs.join("\n") || "No logs."}</pre>
+						<div className="install-logs-area">
+							<div className="install-log-levels">
+								{levelItems.map(level => (
+									<label key={level}>
+										<input
+											type="checkbox"
+											checked={levels[level]}
+											onChange={_=>toggleLevel(level)}
+										/>
+										<span>{level.toUpperCase()}</span>
+									</label>
+								))}
+							</div>
+							<pre className="install-logs">
+								{visibleLogs.map(log=>`[${log.level.toUpperCase()}] ${log.message}`).join("\n") || "No logs for selected levels."}
+							</pre>
+						</div>
 					)}
 				</React.Fragment>
 			) : (
@@ -84,7 +115,23 @@ const FinishTab = ({
 						{showLogs ? "Hide install logs" : "Show install logs"}
 					</Button>
 					{showLogs && (
-						<pre className="install-logs">{logs.join("\n") || "No logs."}</pre>
+						<div className="install-logs-area">
+							<div className="install-log-levels">
+								{levelItems.map(level => (
+									<label key={level}>
+										<input
+											type="checkbox"
+											checked={levels[level]}
+											onChange={_=>toggleLevel(level)}
+										/>
+										<span>{level.toUpperCase()}</span>
+									</label>
+								))}
+							</div>
+							<pre className="install-logs">
+								{visibleLogs.map(log=>`[${log.level.toUpperCase()}] ${log.message}`).join("\n") || "No logs for selected levels."}
+							</pre>
+						</div>
 					)}
 					<Gallery/>
 				</React.Fragment>

--- a/src/web/src/components/FinishTab.jsx
+++ b/src/web/src/components/FinishTab.jsx
@@ -2,6 +2,17 @@ const FinishTab = ({
 	fails, mods, selectedMods
 }) => {
 	const { language, langData } = useApp()
+	const [showLogs, setShowLogs] = React.useState(false)
+	const [logs, setLogs] = React.useState([])
+
+	const toggleLogs = async _ => {
+		if (!showLogs && logs.length === 0){
+			const installLogs = await eel.get_install_logs()()
+			setLogs(installLogs || [])
+		}
+		setShowLogs(prev => !prev)
+	}
+
 	function getKnownError(){
 		if (fails.filter(x=>x.error).length > 0){
 			let known_error = fails.find(x =>
@@ -40,6 +51,12 @@ const FinishTab = ({
 					<Button href="https://github.com/SuperZombi/wot-modpack/issues" style={{fontSize: "12px"}}>
 						<LANG id="report_bug"/>
 					</Button>
+					<Button onClick={toggleLogs} style={{marginLeft: "10px", fontSize: "12px"}}>
+						{showLogs ? "Hide install logs" : "Show install logs"}
+					</Button>
+					{showLogs && (
+						<pre className="install-logs">{logs.join("\n") || "No logs."}</pre>
+					)}
 				</React.Fragment>
 			) : (
 				<React.Fragment>
@@ -63,6 +80,12 @@ const FinishTab = ({
 							<img src="/images/donatello_logo.png" draggable={false}/>
 						</a>
 					</div>
+					<Button onClick={toggleLogs} style={{fontSize: "12px", marginTop: "16px"}}>
+						{showLogs ? "Hide install logs" : "Show install logs"}
+					</Button>
+					{showLogs && (
+						<pre className="install-logs">{logs.join("\n") || "No logs."}</pre>
+					)}
 					<Gallery/>
 				</React.Fragment>
 			)}

--- a/src/web/src/components/FinishTab.jsx
+++ b/src/web/src/components/FinishTab.jsx
@@ -16,10 +16,11 @@ const FinishTab = ({
 	const system_errors = fails.filter(x=>x.error)
 	const mods_errors = fails.filter(x=>x.mod)
 	return (
-		<div>
-			{ fails.length > 0 ? (
-				<React.Fragment>
-					<br/>
+		<div className="finish-tab">
+			<div className="finish-tab-content">
+				{ fails.length > 0 ? (
+					<React.Fragment>
+						<br/>
 					{known_error ? (
 						<h3 style={{color: "red"}} dangerouslySetInnerHTML={{ __html: known_error }}></h3>
 					) : system_errors.length > 0 ? (
@@ -47,7 +48,7 @@ const FinishTab = ({
 						</div>
 					</React.Fragment>
 				) : (
-				<React.Fragment>
+					<React.Fragment>
 					<br/>
 					<h3>
 						{selectedMods.length > 0 ? (
@@ -74,6 +75,7 @@ const FinishTab = ({
 						{!isLogsOpen && <Gallery/>}
 					</React.Fragment>
 				)}
+			</div>
 		</div>
 	)
 }

--- a/src/web/src/components/FinishTab.jsx
+++ b/src/web/src/components/FinishTab.jsx
@@ -2,31 +2,6 @@ const FinishTab = ({
 	fails, mods, selectedMods
 }) => {
 	const { language, langData } = useApp()
-	const [showLogs, setShowLogs] = React.useState(false)
-	const [logs, setLogs] = React.useState([])
-	const [levels, setLevels] = React.useState({
-		info: true,
-		warn: true,
-		error: true,
-		debug: false
-	})
-
-	const toggleLogs = async _ => {
-		if (!showLogs && logs.length === 0){
-			const installLogs = await eel.get_install_logs()()
-			setLogs(installLogs || [])
-		}
-		setShowLogs(prev => !prev)
-	}
-	const toggleLevel = level => {
-		setLevels(prev => ({
-			...prev,
-			[level]: !prev[level]
-		}))
-	}
-
-	const visibleLogs = logs.filter(log => levels[log.level] ?? true)
-	const levelItems = ["info", "warn", "error", "debug"]
 
 	function getKnownError(){
 		if (fails.filter(x=>x.error).length > 0){
@@ -66,28 +41,9 @@ const FinishTab = ({
 					<Button href="https://github.com/SuperZombi/wot-modpack/issues" style={{fontSize: "12px"}}>
 						<LANG id="report_bug"/>
 					</Button>
-					<Button onClick={toggleLogs} style={{marginLeft: "10px", fontSize: "12px"}}>
-						{showLogs ? "Hide install logs" : "Show install logs"}
-					</Button>
-					{showLogs && (
-						<div className="install-logs-area">
-							<div className="install-log-levels">
-								{levelItems.map(level => (
-									<label key={level}>
-										<input
-											type="checkbox"
-											checked={levels[level]}
-											onChange={_=>toggleLevel(level)}
-										/>
-										<span>{level.toUpperCase()}</span>
-									</label>
-								))}
-							</div>
-							<pre className="install-logs">
-								{visibleLogs.map(log=>`[${log.level.toUpperCase()}] ${log.message}`).join("\n") || "No logs for selected levels."}
-							</pre>
-						</div>
-					)}
+					<div style={{marginTop: "8px"}}>
+						<InstallLogsViewer/>
+					</div>
 				</React.Fragment>
 			) : (
 				<React.Fragment>
@@ -111,28 +67,9 @@ const FinishTab = ({
 							<img src="/images/donatello_logo.png" draggable={false}/>
 						</a>
 					</div>
-					<Button onClick={toggleLogs} style={{fontSize: "12px", marginTop: "16px"}}>
-						{showLogs ? "Hide install logs" : "Show install logs"}
-					</Button>
-					{showLogs && (
-						<div className="install-logs-area">
-							<div className="install-log-levels">
-								{levelItems.map(level => (
-									<label key={level}>
-										<input
-											type="checkbox"
-											checked={levels[level]}
-											onChange={_=>toggleLevel(level)}
-										/>
-										<span>{level.toUpperCase()}</span>
-									</label>
-								))}
-							</div>
-							<pre className="install-logs">
-								{visibleLogs.map(log=>`[${log.level.toUpperCase()}] ${log.message}`).join("\n") || "No logs for selected levels."}
-							</pre>
-						</div>
-					)}
+					<div style={{marginTop: "16px"}}>
+						<InstallLogsViewer/>
+					</div>
 					<Gallery/>
 				</React.Fragment>
 			)}

--- a/src/web/src/components/FinishTab.jsx
+++ b/src/web/src/components/FinishTab.jsx
@@ -16,11 +16,10 @@ const FinishTab = ({
 	const system_errors = fails.filter(x=>x.error)
 	const mods_errors = fails.filter(x=>x.mod)
 	return (
-		<div className="finish-tab">
-			<div className="finish-tab-content">
-				{ fails.length > 0 ? (
-					<React.Fragment>
-						<br/>
+		<div>
+			{ fails.length > 0 ? (
+				<React.Fragment>
+					<br/>
 					{known_error ? (
 						<h3 style={{color: "red"}} dangerouslySetInnerHTML={{ __html: known_error }}></h3>
 					) : system_errors.length > 0 ? (
@@ -48,7 +47,7 @@ const FinishTab = ({
 						</div>
 					</React.Fragment>
 				) : (
-					<React.Fragment>
+				<React.Fragment>
 					<br/>
 					<h3>
 						{selectedMods.length > 0 ? (
@@ -75,7 +74,6 @@ const FinishTab = ({
 						{!isLogsOpen && <Gallery/>}
 					</React.Fragment>
 				)}
-			</div>
 		</div>
 	)
 }

--- a/src/web/src/components/InstallLogsViewer.jsx
+++ b/src/web/src/components/InstallLogsViewer.jsx
@@ -1,0 +1,70 @@
+const InstallLogsViewer = () => {
+	const [logs, setLogs] = React.useState([])
+	const [showLogs, setShowLogs] = React.useState(false)
+	const [selectedLevel, setSelectedLevel] = React.useState("info")
+	const [copied, setCopied] = React.useState(false)
+
+	const levelsOrder = ["debug", "info", "warn", "error"]
+	const selectedIndex = levelsOrder.indexOf(selectedLevel)
+	const visibleLevels = levelsOrder.slice(0, selectedIndex + 1)
+	const visibleLogs = logs.filter(log => visibleLevels.includes(log.level))
+	const logsText = visibleLogs.map(log => `[${log.level.toUpperCase()}] ${log.message}`).join("\n")
+
+	const toggleLogs = async _ => {
+		if (!showLogs && logs.length === 0){
+			const installLogs = await eel.get_install_logs()()
+			setLogs(installLogs || [])
+		}
+		setShowLogs(prev => !prev)
+	}
+
+	const copyLogs = async _ => {
+		const textToCopy = logsText || "No logs for selected level."
+		try {
+			await navigator.clipboard.writeText(textToCopy)
+			setCopied(true)
+			setTimeout(()=>setCopied(false), 1200)
+		} catch {
+			const area = document.createElement("textarea")
+			area.value = textToCopy
+			document.body.appendChild(area)
+			area.select()
+			document.execCommand("copy")
+			document.body.removeChild(area)
+			setCopied(true)
+			setTimeout(()=>setCopied(false), 1200)
+		}
+	}
+
+	return (
+		<div className="install-logs-root">
+			<Button onClick={toggleLogs} style={{fontSize: "12px"}}>
+				{showLogs ? "Hide install logs" : "Show install logs"}
+			</Button>
+			{showLogs && (
+				<div className="install-logs-area">
+					<div className="install-log-controls">
+						<label>
+							<span>Log level:</span>
+							<select
+								value={selectedLevel}
+								onChange={e=>setSelectedLevel(e.target.value)}
+							>
+								<option value="debug">DEBUG (+ info, warn, error)</option>
+								<option value="info">INFO (+ warn, error)</option>
+								<option value="warn">WARN (+ error)</option>
+								<option value="error">ERROR</option>
+							</select>
+						</label>
+						<Button onClick={copyLogs} style={{fontSize: "12px"}}>
+							{copied ? "Copied" : "Copy logs"}
+						</Button>
+					</div>
+					<pre className="install-logs">
+						{logsText || "No logs for selected level."}
+					</pre>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/web/src/components/InstallLogsViewer.jsx
+++ b/src/web/src/components/InstallLogsViewer.jsx
@@ -2,12 +2,10 @@ const InstallLogsViewer = ({
 	onVisibilityChange = null
 }) => {
 	const { langData } = useApp()
-	const logsRef = React.useRef(null)
 	const [logs, setLogs] = React.useState([])
 	const [showLogs, setShowLogs] = React.useState(false)
 	const [selectedLevel, setSelectedLevel] = React.useState("info")
 	const [copied, setCopied] = React.useState(false)
-	const [logsMaxHeight, setLogsMaxHeight] = React.useState(null)
 
 	const levelsOrder = ["debug", "info", "warn", "error"]
 	const selectedIndex = levelsOrder.indexOf(selectedLevel)
@@ -29,31 +27,6 @@ const InstallLogsViewer = ({
 		}
 	}, [showLogs])
 
-	React.useEffect(() => {
-		if (!showLogs || !logsRef.current) return
-
-		const updateLogsMaxHeight = () => {
-			if (!logsRef.current) return
-			const top = logsRef.current.getBoundingClientRect().top
-			const available = Math.floor(window.innerHeight - top - 16)
-			setLogsMaxHeight(Math.max(120, available))
-		}
-
-		updateLogsMaxHeight()
-		window.addEventListener("resize", updateLogsMaxHeight)
-
-		let observer = null
-		if (typeof ResizeObserver !== "undefined"){
-			observer = new ResizeObserver(updateLogsMaxHeight)
-			observer.observe(document.body)
-		}
-
-		return () => {
-			window.removeEventListener("resize", updateLogsMaxHeight)
-			if (observer) observer.disconnect()
-		}
-	}, [showLogs, logs.length, selectedLevel])
-
 	const copyLogs = async _ => {
 		const textToCopy = logsText || (langData?.no_logs_for_selected_level || "No logs for selected level.")
 		try {
@@ -72,11 +45,11 @@ const InstallLogsViewer = ({
 		}
 	}
 
-	return (
-			<div className="install-logs-root">
-				<Button onClick={toggleLogs} style={{fontSize: "12px"}}>
-					{showLogs ? <LANG id="hide_install_logs"/> : <LANG id="show_install_logs"/>}
-				</Button>
+		return (
+				<div className="install-logs-root">
+					<Button onClick={toggleLogs} style={{fontSize: "12px", marginTop: "10px"}}>
+						{showLogs ? <LANG id="hide_install_logs"/> : <LANG id="show_install_logs"/>}
+					</Button>
 				{showLogs && (
 					<div className="install-logs-area">
 						<div className="install-log-controls">
@@ -96,13 +69,9 @@ const InstallLogsViewer = ({
 								{copied ? <LANG id="copied"/> : <LANG id="copy_logs"/>}
 							</Button>
 						</div>
-						<pre
-							ref={logsRef}
-							className="install-logs"
-							style={{maxHeight: logsMaxHeight ? `${logsMaxHeight}px` : undefined}}
-						>
-							{logsText || <LANG id="no_logs_for_selected_level"/>}
-						</pre>
+							<pre className="install-logs">
+								{logsText || <LANG id="no_logs_for_selected_level"/>}
+							</pre>
 					</div>
 				)}
 		</div>

--- a/src/web/src/components/InstallLogsViewer.jsx
+++ b/src/web/src/components/InstallLogsViewer.jsx
@@ -1,6 +1,7 @@
 const InstallLogsViewer = ({
 	onVisibilityChange = null
 }) => {
+	const { langData } = useApp()
 	const [logs, setLogs] = React.useState([])
 	const [showLogs, setShowLogs] = React.useState(false)
 	const [selectedLevel, setSelectedLevel] = React.useState("info")
@@ -27,7 +28,7 @@ const InstallLogsViewer = ({
 	}, [showLogs])
 
 	const copyLogs = async _ => {
-		const textToCopy = logsText || "No logs for selected level."
+		const textToCopy = logsText || (langData?.no_logs_for_selected_level || "No logs for selected level.")
 		try {
 			await navigator.clipboard.writeText(textToCopy)
 			setCopied(true)
@@ -45,18 +46,18 @@ const InstallLogsViewer = ({
 	}
 
 	return (
-		<div className="install-logs-root">
-			<Button onClick={toggleLogs} style={{fontSize: "12px"}}>
-				{showLogs ? "Hide install logs" : "Show install logs"}
-			</Button>
-			{showLogs && (
-				<div className="install-logs-area">
-					<div className="install-log-controls">
-						<label>
-							<span>Log level:</span>
-								<select
-									value={selectedLevel}
-									onChange={e=>setSelectedLevel(e.target.value)}
+			<div className="install-logs-root">
+				<Button onClick={toggleLogs} style={{fontSize: "12px"}}>
+					{showLogs ? <LANG id="hide_install_logs"/> : <LANG id="show_install_logs"/>}
+				</Button>
+				{showLogs && (
+					<div className="install-logs-area">
+						<div className="install-log-controls">
+							<label>
+								<span><LANG id="log_level"/>:</span>
+									<select
+										value={selectedLevel}
+										onChange={e=>setSelectedLevel(e.target.value)}
 								>
 									<option value="debug">DEBUG</option>
 									<option value="info">INFO</option>
@@ -64,15 +65,15 @@ const InstallLogsViewer = ({
 									<option value="error">ERROR</option>
 								</select>
 						</label>
-						<Button onClick={copyLogs} style={{fontSize: "12px"}}>
-							{copied ? "Copied" : "Copy logs"}
-						</Button>
+							<Button onClick={copyLogs} style={{fontSize: "12px", marginLeft: "auto"}}>
+								{copied ? <LANG id="copied"/> : <LANG id="copy_logs"/>}
+							</Button>
+						</div>
+						<pre className="install-logs">
+							{logsText || <LANG id="no_logs_for_selected_level"/>}
+						</pre>
 					</div>
-					<pre className="install-logs">
-						{logsText || "No logs for selected level."}
-					</pre>
-				</div>
-			)}
+				)}
 		</div>
 	)
 }

--- a/src/web/src/components/InstallLogsViewer.jsx
+++ b/src/web/src/components/InstallLogsViewer.jsx
@@ -1,4 +1,6 @@
-const InstallLogsViewer = () => {
+const InstallLogsViewer = ({
+	onVisibilityChange = null
+}) => {
 	const [logs, setLogs] = React.useState([])
 	const [showLogs, setShowLogs] = React.useState(false)
 	const [selectedLevel, setSelectedLevel] = React.useState("info")
@@ -17,6 +19,12 @@ const InstallLogsViewer = () => {
 		}
 		setShowLogs(prev => !prev)
 	}
+
+	React.useEffect(() => {
+		if (typeof onVisibilityChange === "function"){
+			onVisibilityChange(showLogs)
+		}
+	}, [showLogs])
 
 	const copyLogs = async _ => {
 		const textToCopy = logsText || "No logs for selected level."

--- a/src/web/src/components/InstallLogsViewer.jsx
+++ b/src/web/src/components/InstallLogsViewer.jsx
@@ -2,10 +2,12 @@ const InstallLogsViewer = ({
 	onVisibilityChange = null
 }) => {
 	const { langData } = useApp()
+	const logsRef = React.useRef(null)
 	const [logs, setLogs] = React.useState([])
 	const [showLogs, setShowLogs] = React.useState(false)
 	const [selectedLevel, setSelectedLevel] = React.useState("info")
 	const [copied, setCopied] = React.useState(false)
+	const [logsMaxHeight, setLogsMaxHeight] = React.useState(null)
 
 	const levelsOrder = ["debug", "info", "warn", "error"]
 	const selectedIndex = levelsOrder.indexOf(selectedLevel)
@@ -26,6 +28,31 @@ const InstallLogsViewer = ({
 			onVisibilityChange(showLogs)
 		}
 	}, [showLogs])
+
+	React.useEffect(() => {
+		if (!showLogs || !logsRef.current) return
+
+		const updateLogsMaxHeight = () => {
+			if (!logsRef.current) return
+			const top = logsRef.current.getBoundingClientRect().top
+			const available = Math.floor(window.innerHeight - top - 16)
+			setLogsMaxHeight(Math.max(120, available))
+		}
+
+		updateLogsMaxHeight()
+		window.addEventListener("resize", updateLogsMaxHeight)
+
+		let observer = null
+		if (typeof ResizeObserver !== "undefined"){
+			observer = new ResizeObserver(updateLogsMaxHeight)
+			observer.observe(document.body)
+		}
+
+		return () => {
+			window.removeEventListener("resize", updateLogsMaxHeight)
+			if (observer) observer.disconnect()
+		}
+	}, [showLogs, logs.length, selectedLevel])
 
 	const copyLogs = async _ => {
 		const textToCopy = logsText || (langData?.no_logs_for_selected_level || "No logs for selected level.")
@@ -69,7 +96,11 @@ const InstallLogsViewer = ({
 								{copied ? <LANG id="copied"/> : <LANG id="copy_logs"/>}
 							</Button>
 						</div>
-						<pre className="install-logs">
+						<pre
+							ref={logsRef}
+							className="install-logs"
+							style={{maxHeight: logsMaxHeight ? `${logsMaxHeight}px` : undefined}}
+						>
 							{logsText || <LANG id="no_logs_for_selected_level"/>}
 						</pre>
 					</div>

--- a/src/web/src/components/InstallLogsViewer.jsx
+++ b/src/web/src/components/InstallLogsViewer.jsx
@@ -6,7 +6,7 @@ const InstallLogsViewer = () => {
 
 	const levelsOrder = ["debug", "info", "warn", "error"]
 	const selectedIndex = levelsOrder.indexOf(selectedLevel)
-	const visibleLevels = levelsOrder.slice(0, selectedIndex + 1)
+	const visibleLevels = levelsOrder.slice(selectedIndex)
 	const visibleLogs = logs.filter(log => visibleLevels.includes(log.level))
 	const logsText = visibleLogs.map(log => `[${log.level.toUpperCase()}] ${log.message}`).join("\n")
 
@@ -46,15 +46,15 @@ const InstallLogsViewer = () => {
 					<div className="install-log-controls">
 						<label>
 							<span>Log level:</span>
-							<select
-								value={selectedLevel}
-								onChange={e=>setSelectedLevel(e.target.value)}
-							>
-								<option value="debug">DEBUG (+ info, warn, error)</option>
-								<option value="info">INFO (+ warn, error)</option>
-								<option value="warn">WARN (+ error)</option>
-								<option value="error">ERROR</option>
-							</select>
+								<select
+									value={selectedLevel}
+									onChange={e=>setSelectedLevel(e.target.value)}
+								>
+									<option value="debug">DEBUG</option>
+									<option value="info">INFO</option>
+									<option value="warn">WARN</option>
+									<option value="error">ERROR</option>
+								</select>
 						</label>
 						<Button onClick={copyLogs} style={{fontSize: "12px"}}>
 							{copied ? "Copied" : "Copy logs"}

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -281,9 +281,11 @@ ul{
 
 .install-logs{
 	margin-top: 12px;
-	max-height: 240px;
+	height: calc(100dvh - 260px);
+	max-height: calc(100dvh - 260px);
 	max-width: 800px;
 	overflow: auto;
+	color-scheme: dark;
 	padding: 10px;
 	text-align: left;
 	white-space: pre-wrap;
@@ -298,6 +300,9 @@ ul{
 .install-logs-area{
 	margin-top: 12px;
 	max-width: 800px;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
 }
 
 .install-log-controls{

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -1,14 +1,9 @@
-:root{
-	--header-height: 50px;
-	--footer-height: 60px;
-}
-
 #root{
-	padding-top: var(--header-height);
-	padding-bottom: var(--footer-height);
+	padding-top: 50px;
+	padding-bottom: 60px;
 }
 header{
-	height: var(--header-height);
+	height: 50px;
 	background-image: url('/images/header.jpg');
 	background-repeat: no-repeat;
 	background-size: cover;
@@ -42,7 +37,7 @@ header a:hover{
 	align-items: center;
 	justify-content: space-between;
 	padding: 0 1em;
-	height: var(--footer-height);
+	height: 60px;
 	position: fixed;
 	bottom: 0;
 	width: 100%;
@@ -144,9 +139,9 @@ header a:hover{
 	overflow: auto;
 	scrollbar-width: thin;
 	color-scheme: dark;
-	height: calc(100dvh - var(--header-height) - var(--footer-height));
+	height: calc(100dvh - 50px - 60px);
 	position: sticky;
-	top: var(--header-height);
+	top: 50px;
 }
 #mod-preview.show{
 	opacity: 1;
@@ -238,7 +233,7 @@ ul{
 	padding: 5px;
 	gap: 5px;
 	position: sticky;
-	top: var(--header-height);
+	top: 50px;
 	z-index: 1;
 	background: #111;
 }
@@ -284,18 +279,6 @@ ul{
 	align-items: center;
 }
 
-.finish-tab{
-	height: calc(100dvh - var(--header-height) - var(--footer-height));
-	width: 100%;
-	display: flex;
-	flex-direction: column;
-}
-.finish-tab-content{
-	flex: 1 1 auto;
-	min-height: 0;
-	overflow: auto;
-}
-
 .install-logs{
 	margin-top: 12px;
 	max-width: 640px;
@@ -303,7 +286,7 @@ ul{
 	color-scheme: dark;
 	flex: 1 1 auto;
 	min-height: 100px;
-	max-height: calc(100dvh - var(--header-height) - var(--footer-height) - 150px);
+	max-height: calc(100dvh - 260px);
 	padding: 10px;
 	text-align: left;
 	white-space: pre-wrap;
@@ -321,7 +304,7 @@ ul{
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-	max-height: calc(100dvh - var(--header-height) - var(--footer-height) - 150px);
+	max-height: calc(100dvh - 260px);
 }
 
 .install-log-controls{

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -281,11 +281,12 @@ ul{
 
 .install-logs{
 	margin-top: 12px;
-	max-width: 800px;
+	max-width: 640px;
 	overflow: auto;
 	color-scheme: dark;
 	flex: 1 1 auto;
-	min-height: 120px;
+	min-height: 100px;
+	max-height: calc(100dvh - 260px);
 	padding: 10px;
 	text-align: left;
 	white-space: pre-wrap;
@@ -299,11 +300,11 @@ ul{
 
 .install-logs-area{
 	margin-top: 12px;
-	max-width: 800px;
+	max-width: 640px;
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-	max-height: calc(100dvh - 220px);
+	max-height: calc(100dvh - 260px);
 }
 
 .install-log-controls{

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -278,6 +278,22 @@ ul{
 	display: flex;
 	align-items: center;
 }
+
+.install-logs{
+	margin-top: 12px;
+	max-height: 240px;
+	max-width: 800px;
+	overflow: auto;
+	padding: 10px;
+	text-align: left;
+	white-space: pre-wrap;
+	word-break: break-word;
+	border: 1px solid #555;
+	border-radius: 8px;
+	background: #0b0b0b;
+	color: #d9d9d9;
+	font-size: 12px;
+}
 .mods-install-list .mod-item:hover{
 	background: rgb(255, 255, 255, 0.1);
 }

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -300,18 +300,26 @@ ul{
 	max-width: 800px;
 }
 
-.install-log-levels{
+.install-log-controls{
 	display: flex;
 	gap: 12px;
 	flex-wrap: wrap;
 	justify-content: flex-start;
+	align-items: center;
 }
-.install-log-levels label{
+.install-log-controls label{
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
 	font-size: 12px;
 	user-select: none;
+}
+.install-log-controls select{
+	background: #111;
+	color: #eee;
+	border: 1px solid #555;
+	border-radius: 4px;
+	padding: 3px 6px;
 }
 .mods-install-list .mod-item:hover{
 	background: rgb(255, 255, 255, 0.1);

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -1,9 +1,14 @@
+:root{
+	--header-height: 50px;
+	--footer-height: 60px;
+}
+
 #root{
-	padding-top: 50px;
-	padding-bottom: 60px;
+	padding-top: var(--header-height);
+	padding-bottom: var(--footer-height);
 }
 header{
-	height: 50px;
+	height: var(--header-height);
 	background-image: url('/images/header.jpg');
 	background-repeat: no-repeat;
 	background-size: cover;
@@ -37,7 +42,7 @@ header a:hover{
 	align-items: center;
 	justify-content: space-between;
 	padding: 0 1em;
-	height: 60px;
+	height: var(--footer-height);
 	position: fixed;
 	bottom: 0;
 	width: 100%;
@@ -139,9 +144,9 @@ header a:hover{
 	overflow: auto;
 	scrollbar-width: thin;
 	color-scheme: dark;
-	height: calc(100dvh - 50px - 60px);
+	height: calc(100dvh - var(--header-height) - var(--footer-height));
 	position: sticky;
-	top: 50px;
+	top: var(--header-height);
 }
 #mod-preview.show{
 	opacity: 1;
@@ -233,7 +238,7 @@ ul{
 	padding: 5px;
 	gap: 5px;
 	position: sticky;
-	top: 50px;
+	top: var(--header-height);
 	z-index: 1;
 	background: #111;
 }
@@ -279,6 +284,18 @@ ul{
 	align-items: center;
 }
 
+.finish-tab{
+	height: calc(100dvh - var(--header-height) - var(--footer-height));
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+}
+.finish-tab-content{
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow: auto;
+}
+
 .install-logs{
 	margin-top: 12px;
 	max-width: 640px;
@@ -286,7 +303,7 @@ ul{
 	color-scheme: dark;
 	flex: 1 1 auto;
 	min-height: 100px;
-	max-height: calc(100dvh - 260px);
+	max-height: calc(100dvh - var(--header-height) - var(--footer-height) - 150px);
 	padding: 10px;
 	text-align: left;
 	white-space: pre-wrap;
@@ -304,7 +321,7 @@ ul{
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-	max-height: calc(100dvh - 260px);
+	max-height: calc(100dvh - var(--header-height) - var(--footer-height) - 150px);
 }
 
 .install-log-controls{

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -1,9 +1,11 @@
 #root{
-	padding-top: 50px;
-	padding-bottom: 60px;
+	--header-height: 50px;
+	--footer-height: 60px;
+	padding-top: var(--header-height);
+	padding-bottom: var(--footer-height);
 }
 header{
-	height: 50px;
+	height: var(--header-height);
 	background-image: url('/images/header.jpg');
 	background-repeat: no-repeat;
 	background-size: cover;
@@ -37,7 +39,7 @@ header a:hover{
 	align-items: center;
 	justify-content: space-between;
 	padding: 0 1em;
-	height: 60px;
+	height: var(--footer-height);
 	position: fixed;
 	bottom: 0;
 	width: 100%;
@@ -139,9 +141,9 @@ header a:hover{
 	overflow: auto;
 	scrollbar-width: thin;
 	color-scheme: dark;
-	height: calc(100dvh - 50px - 60px);
+	height: calc(100dvh - var(--header-height) - var(--footer-height));
 	position: sticky;
-	top: 50px;
+	top: var(--header-height);
 }
 #mod-preview.show{
 	opacity: 1;
@@ -233,7 +235,7 @@ ul{
 	padding: 5px;
 	gap: 5px;
 	position: sticky;
-	top: 50px;
+	top: var(--header-height);
 	z-index: 1;
 	background: #111;
 }
@@ -284,9 +286,8 @@ ul{
 	max-width: 640px;
 	overflow: auto;
 	color-scheme: dark;
-	flex: 1 1 auto;
 	min-height: 100px;
-	max-height: calc(100dvh - 260px);
+	max-height: calc(100dvh - var(--header-height) - var(--footer-height) - 150px);
 	padding: 10px;
 	text-align: left;
 	white-space: pre-wrap;
@@ -297,14 +298,8 @@ ul{
 	color: #d9d9d9;
 	font-size: 12px;
 }
-
 .install-logs-area{
 	margin-top: 12px;
-	max-width: 640px;
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-	max-height: calc(100dvh - 260px);
 }
 
 .install-log-controls{

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -281,8 +281,7 @@ ul{
 
 .install-logs{
 	margin-top: 12px;
-	height: calc(100dvh - 260px);
-	max-height: calc(100dvh - 260px);
+	max-height: 240px;
 	max-width: 800px;
 	overflow: auto;
 	color-scheme: dark;

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -281,10 +281,11 @@ ul{
 
 .install-logs{
 	margin-top: 12px;
-	max-height: 240px;
 	max-width: 800px;
 	overflow: auto;
 	color-scheme: dark;
+	flex: 1 1 auto;
+	min-height: 120px;
 	padding: 10px;
 	text-align: left;
 	white-space: pre-wrap;
@@ -302,6 +303,7 @@ ul{
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
+	max-height: calc(100dvh - 220px);
 }
 
 .install-log-controls{

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -294,6 +294,25 @@ ul{
 	color: #d9d9d9;
 	font-size: 12px;
 }
+
+.install-logs-area{
+	margin-top: 12px;
+	max-width: 800px;
+}
+
+.install-log-levels{
+	display: flex;
+	gap: 12px;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+}
+.install-log-levels label{
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	font-size: 12px;
+	user-select: none;
+}
 .mods-install-list .mod-item:hover{
 	background: rgb(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
### Motivation
- Provide English-language installation logs for the mod installation flow so users can inspect what happened after an install finishes. 
- Make logs available in the UI on demand rather than visible by default to avoid cluttering the interface.

### Description
- Added a global `INSTALL_LOGS` buffer, `add_install_log()` helper, and exposed `eel` method `get_install_logs()` to fetch logs from the frontend. 
- Instrumented `main.py::_main_install_worker()` with English log messages for start, client-running check, mods deletion, per-mod install start/finish/failure, telemetry send, settings save, and worker finish, and wired the `add_install_log` callback into the `Client` constructor. 
- Propagated a `logger` callback into `utils.Client` and `utils.Mod` and added logging inside `Client.delete_mods`, `Client.install_mod`, and `Mod.install` to record cache usage, downloads, local-file operations, required-mod installs, and cache updates. 
- Added a "Show install logs" / "Hide install logs" button in `FinishTab` that fetches logs with `eel.get_install_logs()` and displays them in a styled `<pre>` block, and added CSS rules for `.install-logs` for readable, scrollable output.

### Testing
- Ran `python -m py_compile src/main.py src/utils.py` to validate syntax and byte-compilation, which completed successfully. 
- No additional automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d915662bbc832fafef4b51c7ec65d0)