### PR TITLE
Replace hidden mods checkbox with site-styled switch

### DIFF
--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -60,13 +60,13 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 				</div>
 				<div className="row" style={{marginTop: "1.5rem"}}>
 					<label className="switch-control">
+						<span>{<LANG id="showHiddenMods"/>}</span>
 						<input
 							type="checkbox"
 							checked={showHiddenMods}
 							onChange={e=>setShowHiddenMods(e.target.checked)}
 						/>
 						<span className="switch-slider" aria-hidden="true"></span>
-						<span>{<LANG id="showHiddenMods"/>}</span>
 					</label>
 				</div>
 			</div>

--- a/components/other_page.jsx
+++ b/components/other_page.jsx
@@ -59,11 +59,13 @@ const OtherPage = ({showHiddenMods, setShowHiddenMods, stats}) => {
 					</a>
 				</div>
 				<div className="row" style={{marginTop: "1.5rem"}}>
-					<label>
-						<input type="checkbox" checked={showHiddenMods}
+					<label className="switch-control">
+						<input
+							type="checkbox"
+							checked={showHiddenMods}
 							onChange={e=>setShowHiddenMods(e.target.checked)}
-							style={{marginRight: "0.5em"}}
 						/>
+						<span className="switch-slider" aria-hidden="true"></span>
 						<span>{<LANG id="showHiddenMods"/>}</span>
 					</label>
 				</div>

--- a/web/main.css
+++ b/web/main.css
@@ -320,6 +320,52 @@ table td, table caption{
 	flex-wrap: wrap;
 	align-items: flex-start;
 }
+.switch-control{
+	display: inline-flex;
+	align-items: center;
+	gap: 0.6rem;
+	cursor: pointer;
+	user-select: none;
+}
+.switch-control input{
+	position: absolute;
+	opacity: 0;
+	width: 1px;
+	height: 1px;
+}
+.switch-slider{
+	width: 44px;
+	height: 24px;
+	flex: 0 0 auto;
+	border-radius: 100px;
+	background: rgba(255, 255, 255, 0.12);
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	position: relative;
+	transition: all 0.2s ease;
+}
+.switch-slider::before{
+	content: '';
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 18px;
+	height: 18px;
+	border-radius: 50%;
+	background: rgba(255, 255, 255, 0.95);
+	box-shadow: 0 2px 6px rgba(0,0,0,0.35);
+	transition: transform 0.2s ease;
+}
+.switch-control input:checked + .switch-slider{
+	background: linear-gradient(to right, #06BFFF, #2B74FF);
+	border-color: rgba(124,196,255,0.55);
+}
+.switch-control input:checked + .switch-slider::before{
+	transform: translateX(20px);
+}
+.switch-control input:focus-visible + .switch-slider{
+	outline: 2px solid rgba(124,196,255,0.8);
+	outline-offset: 2px;
+}
 .line {
 	display: flex;
     flex-direction: column;

--- a/web/main.css
+++ b/web/main.css
@@ -323,44 +323,44 @@ table td, table caption{
 .switch-control{
 	display: inline-flex;
 	align-items: center;
-	gap: 0.6rem;
+	gap: 0.5em;
 	cursor: pointer;
 	user-select: none;
 }
 .switch-control input{
 	position: absolute;
 	opacity: 0;
-	width: 1px;
-	height: 1px;
+	width: 0;
+	height: 0;
 }
 .switch-slider{
-	width: 44px;
-	height: 24px;
+	width: 2em;
+	height: 1em;
 	flex: 0 0 auto;
 	border-radius: 100px;
 	background: rgba(255, 255, 255, 0.12);
 	border: 1px solid rgba(255, 255, 255, 0.2);
 	position: relative;
-	transition: all 0.2s ease;
 }
 .switch-slider::before{
 	content: '';
 	position: absolute;
-	top: 2px;
-	left: 2px;
-	width: 18px;
-	height: 18px;
+	top: 50%;
+	left: 0.1em;
+	width: 0.7em;
+	height: 0.7em;
+	transform: translateY(-50%);
 	border-radius: 50%;
 	background: rgba(255, 255, 255, 0.95);
 	box-shadow: 0 2px 6px rgba(0,0,0,0.35);
-	transition: transform 0.2s ease;
+	transition: left 0.25s ease;
 }
 .switch-control input:checked + .switch-slider{
 	background: linear-gradient(to right, #06BFFF, #2B74FF);
 	border-color: rgba(124,196,255,0.55);
 }
 .switch-control input:checked + .switch-slider::before{
-	transform: translateX(20px);
+	left: 1.1em;
 }
 .switch-control input:focus-visible + .switch-slider{
 	outline: 2px solid rgba(124,196,255,0.8);


### PR DESCRIPTION
### Motivation
- Improve visual consistency of the `Other` page by replacing the plain checkbox for `Show hidden mods` with a site-styled switch that matches the dark glass + blue accent design and provides better focus indication.

### Description
- Replaced the checkbox markup in `components/other_page.jsx` with a structured switch: `label.switch-control` containing the hidden `input[type=checkbox]`, decorative `span.switch-slider`, and the label text bound to `<LANG id="showHiddenMods"/>` while preserving the existing `checked={showHiddenMods}` binding and `onChange` handler.
- Added CSS for the switch in `web/main.css` including track, knob, checked-state gradient, and `focus-visible` outline to match site styling and accessibility.
- No behavioral changes to state or handlers; only markup and styles were updated.

### Testing
- Ran `npm run build` which completed successfully and produced the build artifacts (React build reported done).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea74cc2ef0832f8b61d9b50aa9e9f2)