### PR TITLE
Remove commented code and unused CSS from web frontend

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -12,12 +12,10 @@
 	<link rel='stylesheet' href="/fontawesome/css/all.min.css">
 	<link href="/styles/bebas-neue.css" rel="stylesheet">
 
-	<!-- React -->
 	<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
 	<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
 	<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
-	<!-- Main -->
 	<script type="text/babel" data-presets="react" src="src/components/ModList.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/ModsTab.jsx"></script>
 	<script type="text/babel" data-presets="react" src="src/components/HomeTab.jsx"></script>

--- a/src/web/src/components/ModList.jsx
+++ b/src/web/src/components/ModList.jsx
@@ -1,9 +1,8 @@
 function ModList({
 	activeCat,
-	mods, groups, categories, stats, search,
+	mods, groups, stats, search,
 	selectedMods, setSelectedMods, setPreview, setDisplayPreview,
 	cachedMods, selectedClient,
-	// forceOpen=false
 }) {
 	const toggleMod = (modId, value=null) => {
 		setSelectedMods(prev => {
@@ -33,10 +32,6 @@ function ModList({
 		if (mod.description && Object.values(mod.description).some(v => v.toLowerCase().includes(s))) return true;
 		return false;
 	}
-	// const anyMatch = categories.some(cat => {
-	// 	const catMods = mods.filter(m => m.category === cat.name)
-	// 	return catMods.some(mod => matchesSearch(mod, search))
-	// })
 	function sortByPopularityWithGroups(mods) {
 		const groupPopularity = {}
 		for (const g of groups) {
@@ -83,7 +78,6 @@ function ModList({
 						<Group
 							key={group.id}
 							id={group.id}
-							title={group.title}
 							mods={modsInGroup}
 							stats={stats}
 							selectedMods={selectedMods}
@@ -108,112 +102,14 @@ function ModList({
 	)
 }
 
-// function Category({
-// 	mods, groups, stats,
-// 	search, matchesSearch,
-// 	selectedMods, toggleMod,
-// 	setPreview, setDisplayPreview,
-// 	cachedMods, forceOpen=false
-// }) {
-// 	function sortByPopularityWithGroups(mods) {
-// 		const groupPopularity = {}
-// 		for (const g of groups) {
-// 			const modsInGroup = mods.filter(m => m.group === g.id)
-// 			if (modsInGroup.length) {
-// 				groupPopularity[g.id] = Math.max(...modsInGroup.map(m => stats[m.id] || 0))
-// 			}
-// 		}
-// 		return [...mods].sort((a, b) => {
-// 			const popA = a.group ? groupPopularity[a.group] : (stats[a.id] || 0)
-// 			const popB = b.group ? groupPopularity[b.group] : (stats[b.id] || 0)
-// 			return popB - popA;
-// 		})
-// 	}
-// 	const { settings } = useApp()
-// 	const filteredMods = mods.filter(mod => matchesSearch(mod, search))
-// 	const allModsSorted = sortByPopularityWithGroups(filteredMods)
-// 	const [opened, setOpened] = React.useState(forceOpen)
-// 	React.useEffect(_=>{
-// 		setOpened(forceOpen || search.length > 0)
-// 	}, [forceOpen, search])
-
-// 	if (!filteredMods.length) return null;
-
-// 	return (
-// 		<div className="details category">
-// 			<label className="summary hover">
-// 				<input type="checkbox" checked={opened} onChange={e=>setOpened(e.target.checked)}/>
-// 				{icon && <img src={icon} draggable={false}/>}
-// 				<span>{title[settings.language]}</span>
-// 			</label>
-				
-// 			<div className="collapse">
-// 				<div className="wrapper">
-// 					<div className={`content ${settings.layout=="grid"?"mods-grid":""}`}>
-// 						{allModsSorted.map(mod => {
-// 							if (mod.group) {
-// 								const group = groups.find(g => g.id === mod.group);
-// 								if (!group) return null;
-
-// 								const alreadyRendered = allModsSorted.findIndex(m => m.group === group.id) < allModsSorted.indexOf(mod);
-// 								if (alreadyRendered) return null;
-
-// 								const modsInGroup = allModsSorted.filter(m => m.group === group.id)
-// 								return (
-// 									<Group
-// 										key={group.id}
-// 										id={group.id}
-// 										title={group.title}
-// 										mods={modsInGroup}
-// 										stats={stats}
-// 										selectedMods={selectedMods}
-// 										toggleMod={toggleMod}
-// 										setPreview={setPreview}
-// 										setDisplayPreview={setDisplayPreview}
-// 										cachedMods={cachedMods}
-// 									/>
-// 								)
-// 							}
-// 							return <Mod
-// 								key={mod.id}
-// 								mod={mod}
-// 								selectedMods={selectedMods}
-// 								cachedMods={cachedMods}
-// 								onChange={() => toggleMod(mod.id)}
-// 								setPreview={setPreview}
-// 								setDisplayPreview={setDisplayPreview}
-// 							/>
-// 						})}
-// 					</div>
-// 				</div>
-// 			</div>
-
-			
-// 		</div>
-// 	)
-// }
-
 function Group({
-	id, title, mods, stats,
+	id, mods, stats,
 	selectedMods, toggleMod,
 	setPreview, setDisplayPreview,
 	cachedMods
 }) {
 	const sortByPopularity = (arr) => arr.sort((a, b) => (stats[b.id] || 0) - (stats[a.id] || 0))
-	const [groupChecked, setGroupChecked] = React.useState(false)
-	const onGroupCheck = e => {
-		const value = e.target.checked
-		setGroupChecked(value)
-		if (!value){
-			mods.forEach(mod=>{
-				toggleMod(mod.id, false)
-			})
-		} else {
-			toggleMod(mods[0].id, true)
-		}
-	}
 	const onModCheck = (mod_id, value) => {
-		setGroupChecked(value)
 		mods.forEach(mod=>{
 			toggleMod(mod.id, false)
 		})
@@ -221,11 +117,6 @@ function Group({
 			toggleMod(mod_id, value)
 		}
 	}
-	React.useEffect(_=>{
-		setGroupChecked(mods.some(mod => selectedMods.includes(mod.id)))
-	}, [selectedMods])
-
-	const {settings} = useApp()
 
 	return (
 		<React.Fragment>
@@ -244,37 +135,6 @@ function Group({
 			))}
 		</React.Fragment>
 	)
-	// return (
-	// 	<div className="details group">
-	// 		<label className="summary hover">
-	// 			<input
-	// 				type="checkbox"
-	// 				checked={groupChecked}
-	// 				onChange={onGroupCheck}
-	// 			/>
-	// 			<span>{title[settings.language]}</span>
-	// 		</label>
-	// 		<div className="collapse">
-	// 			<div className="wrapper">
-	// 				<div className="content">
-	// 					{sortByPopularity(mods).map(mod => (
-	// 						<Mod
-	// 							key={mod.id}
-	// 							type="radio"
-	// 							name={id}
-	// 							mod={mod}
-	// 							selectedMods={selectedMods}
-	// 							cachedMods={cachedMods}
-	// 							onChange={e=>onModCheck(mod.id, e.target.checked)}
-	// 							setPreview={setPreview}
-	// 							setDisplayPreview={setDisplayPreview}
-	// 						/>
-	// 					))}
-	// 				</div>
-	// 			</div>
-	// 		</div>
-	// 	</div>
-	// )
 }
 
 function Mod({
@@ -351,21 +211,4 @@ function Mod({
 			}
 		</label>
 	)
-	// return (
-	// 	<label className="mod hover" onMouseOver={onMouse} onMouseOut={_=>setDisplayPreview(false)}>
-	// 		<input
-	// 			className="hover"
-	// 			type={type}
-	// 			checked={checked}
-	// 			onChange={onChange}
-	// 			{...(name && { name })}
-	// 		/>
-	// 		<span>{replaceFlags(mod.title[settings.language])}</span>
-	// 		{
-	// 			(cached_ver && cached_ver != mod.ver) && (
-	// 				<i className="new-badge" title={langData["mod_updated"]}/>
-	// 			)
-	// 		}
-	// 	</label>
-	// )
 }

--- a/src/web/src/components/ModsTab.jsx
+++ b/src/web/src/components/ModsTab.jsx
@@ -9,19 +9,12 @@ const ModsTab = ({
 	const [modPreview, setPreview] = React.useState(null)
 	const [displayPreview, setDisplayPreview] = React.useState(false)
 
-	const {langData, settings, updateSetting} = useApp()
+	const {langData, settings} = useApp()
 	const audioRef = React.useRef(null)
 	const [imageLoaded, setImageLoaded] = React.useState(false)
 
 	const [activeCat, setActiveCat] = React.useState()
 
-	// const [forceOpenCategories, setForceOpenCategories] = React.useState(false)
-	// const [needToShowTooltip, setNeedToShowTooltip] = React.useState(settings.layout_tooltip)
-	// const tooltipOnClick = () => {
-	// 	setNeedToShowTooltip(false)
-	// 	updateSetting("layout_tooltip", false)
-	// 	setForceOpenCategories(true)
-	// }
 
 	React.useEffect(() => {
 		setActiveCat(categories[0]?.name)
@@ -87,10 +80,6 @@ const ModsTab = ({
 		reader.readAsText(droppedFile)
 	}
 
-	// const layoutButtonStyle = {
-	// 	display: "flex",
-	// 	boxShadow: (needToShowTooltip && settings.layout == "list") ? "0 0 10px orange" : null
-	// }
 
 	return (
 		<React.Fragment>
@@ -126,7 +115,6 @@ const ModsTab = ({
 						<ModList
 							activeCat={activeCat}
 							mods={mods}
-							categories={categories}
 							groups={groups}
 							stats={stats}
 							search={search}

--- a/src/web/src/components/UpdatePopup.jsx
+++ b/src/web/src/components/UpdatePopup.jsx
@@ -31,19 +31,6 @@ const Popup = ({
 	)
 }
 
-// const UpdatePopup = ({onClose}) => {
-// 	return (
-// 		<Popup onClose={onClose}>
-// 			<div className="flex-center">
-// 				<img src="/images/up-arrow.svg" height="64" draggable={false} style={{userSelect: "none"}}/>
-// 				<h3><LANG id="update_available"/></h3>
-// 				<Button href="https://github.com/SuperZombi/wot-modpack/releases">
-// 					<LANG id="download"/>
-// 				</Button>
-// 			</div>
-// 		</Popup>
-// 	)
-// }
 const DataCollectionPopup = ({onClose}) => {
 	const { langData } = useApp()
 	return (

--- a/src/web/styles/base.css
+++ b/src/web/styles/base.css
@@ -13,10 +13,6 @@ body{
 	cursor: url('/images/cursor-normal.png'), auto;
 	font-family: sans-serif;
 	color: var(--text-color);
-	/* background-color: #111;
-	background-image: url('/images/sparks.png');
-	background-repeat: repeat-y;
-	background-position: top center; */
 
 	background: radial-gradient(900px 500px at 10% 10%, rgba(45, 212, 191, 0.16), transparent 80%), radial-gradient(800px 600px at 90% 20%, rgba(139, 92, 246, 0.16), transparent 80%), radial-gradient(900px 600px at 40% 90%, rgba(59, 130, 246, 0.12), transparent 75%), #0b0f19;
 	background-attachment: fixed;
@@ -32,14 +28,6 @@ body{
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	padding: 1rem;
 	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-}
-
-#tabs-area .tab{
-	display: none;
-	height: calc(100vh - 50px);
-}
-#tabs-area .tab.active{
-	display: block;
 }
 
 .flex-center {
@@ -59,22 +47,11 @@ body{
 	justify-content: center;
 	align-items: center;
 }
-.flex-row {
-	display: grid;
-	grid-template-columns: auto auto 1fr;
-	align-items: center;
-	gap: 10px;
-	width: fit-content;
-	margin: auto;
-}
 .shade{
 	position: fixed;
 	inset: 0;
 	background: rgb(0, 0, 0, 0.5);
 	z-index: 3;
-}
-.hide{
-	display: none !important;
 }
 
 .hover:hover{
@@ -100,12 +77,6 @@ body{
 	background: rgba(255, 255, 255, 0.12);
 	color: #fff;
 }
-/* .button:active{
-	background: linear-gradient(0deg, #343429, #696a52);
-}
-.button.selected{
-	background: linear-gradient(0deg, #343429, #696a52);
-} */
 
 .version {
 	font-size: 0.85em;
@@ -227,7 +198,6 @@ input[type=checkbox]:checked::before {
 	opacity: 1;
 }
 
-
 input[type=radio]{
 	appearance: none;
 	font-size: inherit;
@@ -258,7 +228,6 @@ input[type=radio]:checked::before {
 	opacity: 1;
 }
 
-
 input[type=text],
 input[type=search]{
 	appearance: none;
@@ -270,10 +239,7 @@ input[type=search]{
 	background: rgba(255, 255, 255, 0.06);
 	border: 1px solid rgba(255, 255, 255, 0.1);
 }
-/* input[type=text]::selection {
-	background: #ea850a;
-	color: black;
-} */
+
 textarea{
 	color: var(--text-color);
 	background: #222;
@@ -287,16 +253,6 @@ progress{
 	border: 1px solid rgba(255, 255, 255, 0.2);
 	border-radius: 99px;
 	overflow: hidden;
-
-	/* height: 10px;
-	border: solid 2px transparent;
-	border-radius: 2px;
-	background: linear-gradient(0deg, #6e3f15, #f7d670) border-box; */
-/* 
-	height: 6px;
-	border-radius: 99px;
-	background: linear-gradient(90deg, #f5a623, #e8470a);
-	transition: width 0.4s ease; */
 }
 progress::-webkit-progress-bar {
 	background: rgba(255, 255, 255, 0.1);
@@ -313,77 +269,6 @@ label{
 	width: fit-content;
 	line-height: 1em;
 }
-
-
-.details .collapse {
-	display: grid;
-	grid-template-rows: 0fr;
-	transition: grid-template-rows 0.3s;
-	overflow: hidden;
-}
-.details > .collapse > .wrapper > .content {
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-	padding: 0.75rem;
-}
-.details.category > .collapse > .wrapper > .content {
-	padding-top: 0.25rem;
-}
-.details .collapse .wrapper{
-	min-height: 0;
-}
-.details.category > .summary > input[type=checkbox]{
-	display: none;
-}
-.details > .summary:has(input[type=checkbox]:checked) + .collapse{
-	grid-template-rows: 1fr;
-}
-
-
-.category{
-	background: #272727;
-	border-radius: 6px;
-	margin: 5px;
-}
-.category img{
-	height: 30px;
-}
-.category > .summary{
-	width: 100%;
-	font-size: 20px;
-	padding: 10px 5px;
-	height: 50px;
-	gap: 0;
-}
-.category > .summary > span {
-	margin-left: 5px;
-	font-weight: bold;
-}
-.category > .summary::after{
-	content: '⯆';
-	transform: rotate(-90deg);
-	margin-left: auto;
-	margin-right: 5px;
-	transition: 0.25s;
-}
-.category > .summary:has(input[type=checkbox]:checked)::after{
-	transform: rotate(0deg);
-}
-.category > .content{
-	padding: 5px;
-}
-
-
-.group .content {
-	margin-left: 0.5rem;
-	padding-top: 1rem !important;
-	padding-bottom: 0.25rem !important;
-}
-.group .summary::after{
-	content: '⯆';
-}
-
 
 .popup {
 	position: fixed;
@@ -538,11 +423,6 @@ section .row .row-label{
 	opacity: 0;
 	pointer-events: none;
 	transition: opacity 0.2s;
-}
-[tooltip].tooltip-right::before{
-	left: 120%;
-	bottom: 50%;
-	transform: translateY(50%);
 }
 [tooltip].tooltip-left::before{
 	left: unset;

--- a/src/web/styles/main.css
+++ b/src/web/styles/main.css
@@ -1,23 +1,10 @@
-/* #root{
-	--header-height: 50px;
-	--footer-height: 60px;
-	padding-top: var(--header-height);
-	padding-bottom: var(--footer-height);
-} */
+
 header{
-	/* height: var(--header-height); */
-	/* background-image: url('/images/header.jpg');
-	background-repeat: no-repeat;
-	background-size: cover; */
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0.6em 1rem !important;
 	user-select: none;
-	/* position: fixed;
-	top: 0;
-	width: 100%;
-	z-index: 2; */
 }
 header .header-container {
 	display: flex;
@@ -49,28 +36,13 @@ header .button {
 	align-items: center;
 	justify-content: space-between;
 	padding: 0.5em 1em;
-	/* height: var(--footer-height);
-	position: fixed;
-	bottom: 0;
-	width: 100%;
-	z-index: 2;
-	
-	background: rgb(17, 17, 17, 0.5);
-	 */
+
 	backdrop-filter: blur(10px);
 	margin-top: auto;
 }
 .bottom-buttons:empty{
 	padding: 0
 }
-/* 
-#setting_button{
-	height: 30px;
-	transition: 0.2s;
-}
-#setting_button:hover{
-	transform: rotate(90deg);
-} */
 
 #mods-area{
 	display: grid;
@@ -120,9 +92,6 @@ header .button {
 	color: #f5a623;
 }
 
-/* #mods-list{
-	margin-top: -5px;
-} */
 #mods-list-area{
 	display: grid !important;
 	grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
@@ -150,16 +119,10 @@ header .button {
 	transform: translateY(-2px);
 }
 #mods-list-area .mod:has(input:checked){
-	/* background: radial-gradient(#2e2e28 25%, black) padding-box,
-		linear-gradient(0deg, #6e3f15, #f7d670) border-box;
-	border: solid 3px transparent; */
 	border-color: rgba(245, 166, 35, 0.6);
     background: rgba(245, 166, 35, 0.16);
 }
-/* #mods-list-area .mod:has(input:checked):hover{
-	background: radial-gradient(#2e2e28 25%, #333) padding-box,
-		linear-gradient(0deg, #6e3f15, #f7d670) border-box;
-} */
+
 #mods-list-area .mod .image-container{
 	overflow: hidden;
 	display: flex;
@@ -181,13 +144,6 @@ header .button {
 #mods-list-area .mod input{
 	display: none;
 }
-#mods-list-area .mod .new-badge{
-	position: absolute;
-	top: 4px;
-	right: 4px;
-	width: 12px;
-	height: 12px;
-}
 #mods-list-area .mod .checkmark {
 	position: absolute;
 	border-radius: 50%;
@@ -203,19 +159,13 @@ header .button {
 	aspect-ratio: 1;
 }
 
-
 #mod-preview{
 	padding: 5px;
 	overflow: auto;
 	scrollbar-width: thin;
 	color-scheme: dark;
-	/* height: calc(100dvh - var(--header-height) - var(--footer-height));
-	position: sticky;
-	top: var(--header-height); */
 }
-/* #mod-preview.show{
-	opacity: 1;
-} */
+
 #mod-preview .image-container{
 	height: 300px;
 	display: flex;
@@ -416,14 +366,6 @@ ul{
 	margin-right: 5px;
 }
 
-#app-version{
-	font-family: monospace;
-	font-size: 14px;
-	background: #666;
-	padding: 2px 6px;
-	border-radius: 12px;
-}
-
 .links {
 	display: flex;
 	justify-content: center;
@@ -439,9 +381,6 @@ ul{
 	padding: 4px 8px;
 	border-radius: 6px;
 }
-#cache_size{
-	margin-right: 2px;
-}
 
 .finish-tab-header {
 	display: flex;
@@ -454,14 +393,6 @@ ul{
 	color: #5de08c;
 	font-size: 2rem;
 }
-
-/* .new-badge{
-	width: 10px;
-	height: 10px;
-	background: red;
-	border-radius: 50%;
-	cursor: help;
-} */
 
 .progress-area {
 	display: grid;


### PR DESCRIPTION
### Motivation
- Reduce dead/commented code and shrink CSS surface area in the web UI to make maintenance easier and avoid carrying unused styles and legacy markup.

### Description
- Removed HTML and JS comment blocks and legacy alternate implementations from the web frontend, notably clearing commented sections in `src/web/index.html`, `src/web/src/components/ModList.jsx`, `src/web/src/components/ModsTab.jsx`, and `src/web/src/components/UpdatePopup.jsx`.
- Simplified component interfaces by removing unused props/state and obsolete code paths (old `Category`/group collapse variants and `UpdatePopup` stub) in `ModList` and `ModsTab` so only active code paths remain.
- Removed obsolete and commented CSS rules from `src/web/styles/base.css` and `src/web/styles/main.css` (tabs, `.details`/`.category`/`.group` collapse styles, `new-badge`, `hide`, `flex-row`, app/version helpers and other commented blocks) to keep only active selectors used by the components.
- Kept UI behaviour intact by preserving active components and styles (popups, mod list grid, sidebar, tooltips, toggles) and updated the HTML includes to a cleaner state in `index.html`.

### Testing
- Ran `npm run build` and the build completed successfully with React and CSS steps reported as done. (success)
- Ran `git diff --check` to verify no whitespace/merge artefacts and found no issues. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c41a5cc18832fa9ee9dd030348b91)